### PR TITLE
Switch to using a procedural macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.1.5"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros to wrap closures such that they can serialized and 
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.1.5"
+documentation = "https://docs.rs/serde_closure/0.2.0"
 readme = "README.md"
 edition = "2018"
 
@@ -23,7 +23,7 @@ azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-serde_closure_derive = { path = "serde_closure_derive", version = "0.1.5" }
+serde_closure_derive = { version = "=0.2.0", path = "serde_closure_derive" }
 serde_derive = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 proc-macro-hack = "0.5"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_closure/0.1.5)
+[Docs](https://docs.rs/serde_closure/0.2.0)
 
 Serializable closures.
 
@@ -29,9 +29,9 @@ features (rust issue
 [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.1.5/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.1.5/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.1.5/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2.0/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2.0/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2.0/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-07-19
+      rust_lint_toolchain: nightly-2019-10-04
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,4 +29,4 @@ jobs:
         rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
       linux:
         imageName: 'ubuntu-16.04'
-        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl'
+        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu' # seems to currently be broken, TODO: x86_64-unknown-linux-musl i686-unknown-linux-musl

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,7 +1,5 @@
-[workspace]
-
 [package]
-name = "serde_closure"
+name = "serde_closure_derive"
 version = "0.1.5"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
@@ -11,23 +9,26 @@ description = """
 Serializable closures.
 
 This library provides macros to wrap closures such that they can serialized and sent between other processes running the same binary.
+
+See [`serde_closure`](https://crates.io/crates/serde_closure) for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
 documentation = "https://docs.rs/serde_closure/0.1.5"
-readme = "README.md"
 edition = "2018"
 
 [badges]
 azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
-[dependencies]
-serde_closure_derive = { path = "serde_closure_derive", version = "0.1.5" }
-serde_derive = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-proc-macro-hack = "0.5"
+[lib]
+proc-macro = true
 
-[dev-dependencies]
-serde_json = "1.0"
-bincode = "1.0"
+[dependencies]
+proc-macro2 = { version = "1.0.1", default-features = false }
+proc-macro-hack = "0.5"
+quote = { version = "1.0.2", default-features = false }
+syn = { version = "1.0.5", default-features = false, features = ["clone-impls", "full", "parsing", "printing", "proc-macro"] }
+
+[features]
+assert-hack = []

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.1.5"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See [`serde_closure`](https://crates.io/crates/serde_closure) for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.1.5"
+documentation = "https://docs.rs/serde_closure/0.2.0"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -1,0 +1,741 @@
+//! Serializable closures.
+//!
+//! **[Crates.io](https://crates.io/crates/serde_closure) │
+//! [Repo](https://github.com/alecmocatta/serde_closure)**
+//!
+//! This library provides macros to wrap closures such that they can be
+//! serialized and sent between other processes running the same binary.
+//!
+//! See [`serde_closure`](https://docs.rs/serde_closure/) for
+//! documentation.
+
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.1.5")]
+#![allow(non_snake_case)] // due to proc-macro-hack can't apply this directly
+
+extern crate proc_macro;
+
+use proc_macro2::{Span, TokenStream};
+use proc_macro_hack::proc_macro_hack;
+use quote::quote;
+use std::{collections::HashSet, iter, iter::successors};
+use syn::{
+	parse::{Parse, ParseStream}, parse2, token::Bracket, Arm, Block, Error, Expr, ExprArray, ExprAssign, ExprAssignOp, ExprAsync, ExprAwait, ExprBinary, ExprBlock, ExprBox, ExprBreak, ExprCall, ExprCast, ExprClosure, ExprField, ExprForLoop, ExprGroup, ExprIf, ExprIndex, ExprLet, ExprLoop, ExprMatch, ExprMethodCall, ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprType, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue, Ident, Local, Member, Pat, PatBox, PatIdent, PatReference, PatSlice, PatTuple, PatTupleStruct, PatType, Path, PathArguments, PathSegment, Stmt, Type, TypeInfer, TypeReference, UnOp
+};
+
+#[proc_macro_hack]
+pub fn Fn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	syn::parse::<Closure>(input)
+		.and_then(|closure| impl_fn_once(closure, Kind::Fn))
+		.unwrap_or_else(|err| err.to_compile_error())
+		.into()
+}
+#[proc_macro_hack]
+pub fn FnMut(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	syn::parse::<Closure>(input)
+		.and_then(|closure| impl_fn_once(closure, Kind::FnMut))
+		.unwrap_or_else(|err| err.to_compile_error())
+		.into()
+}
+#[proc_macro_hack]
+pub fn FnOnce(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	syn::parse::<Closure>(input)
+		.and_then(|closure| impl_fn_once(closure, Kind::FnOnce))
+		.unwrap_or_else(|err| err.to_compile_error())
+		.into()
+}
+
+struct Closure {
+	env: Option<ExprArray>,
+	closure: ExprClosure,
+}
+impl Parse for Closure {
+	fn parse(input: ParseStream) -> Result<Self, Error> {
+		let env = if input.peek(Bracket) {
+			Some(input.parse()?)
+		} else {
+			None
+		};
+		let closure = input.parse()?;
+		Ok(Closure { env, closure })
+	}
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Kind {
+	Fn,
+	FnMut,
+	FnOnce,
+}
+impl Kind {
+	fn name(self) -> &'static str {
+		match self {
+			Kind::Fn => "Fn",
+			Kind::FnMut => "FnMut",
+			Kind::FnOnce => "FnOnce",
+		}
+	}
+}
+
+#[allow(clippy::cognitive_complexity)]
+fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
+	let span = Span::call_site(); // TODO: def_site() https://github.com/rust-lang/rust/issues/54724
+	let name = Ident::new(kind.name(), span);
+	let env_name = Ident::new("__serde_closure_env", span);
+	let ret_name = Ident::new("__serde_closure_ret", span);
+	let env_types_name = Ident::new("__serde_closure_env_types", span);
+
+	let _ = closure.env;
+	let closure = closure.closure;
+	let capture = closure.capture.is_some();
+	let mut closure = Expr::Closure(closure);
+	let mut env_variables = HashSet::new();
+	do_expr(
+		&mut closure,
+		&mut HashSet::new(),
+		&mut env_variables,
+		kind != Kind::FnOnce && !capture,
+		&env_name,
+	);
+	let mut env_variables: Vec<Ident> = env_variables.into_iter().collect();
+	env_variables.sort();
+	let env_variables = &env_variables;
+	let closure = if let Expr::Closure(closure) = closure {
+		closure
+	} else {
+		unreachable!()
+	};
+
+	let attrs = closure.attrs;
+	let asyncness = closure.asyncness;
+	let capture = closure.capture;
+	let output = closure.output;
+	let body = closure.body;
+	let input_pats = closure.inputs.iter().map(|input| match input {
+		Pat::Type(pat_type) => (*pat_type.pat).clone(),
+		pat => (*pat).clone(),
+	});
+	let input_types = closure.inputs.iter().map(pat_to_type);
+
+	let type_params = &(0..env_variables.len())
+		.map(|i| {
+			Ident::new(
+				&format!("__SERDE_CLOSURE_{}", bijective_base(i as u64, 26, alpha)),
+				span,
+			)
+		})
+		.collect::<Vec<_>>();
+
+	let type_params_infer = (0..env_variables.len()).map(|_| TypeInfer {
+		underscore_token: Default::default(),
+	});
+
+	let ret_ref: Expr = parse2(match kind {
+		Kind::Fn => quote! { &#ret_name },
+		Kind::FnMut => quote! { &mut #ret_name },
+		Kind::FnOnce => quote! { #ret_name },
+	})
+	.unwrap();
+	let env_deref: Expr = parse2(match kind {
+		Kind::Fn => quote! { *#env_name },
+		Kind::FnMut => quote! { *#env_name },
+		Kind::FnOnce => quote! { #env_name },
+	})
+	.unwrap();
+	let env_type: Type = parse2(match kind {
+		Kind::Fn => quote! { &#name<#(#type_params_infer,)*_> },
+		Kind::FnMut => quote! { &mut #name<#(#type_params_infer,)*_> },
+		Kind::FnOnce => quote! { #name<#(#type_params_infer,)*_> },
+	})
+	.unwrap();
+	let env_capture = parse2::<ExprTuple>(match (kind, capture.is_some()) {
+		(Kind::Fn, false) => quote! { ( #( & #env_variables ,)* ) },
+		(Kind::FnMut, false) => quote! { ( #( &mut #env_variables ,)* ) },
+		_ => quote! { ( #( #env_variables ,)* ) },
+	})
+	.unwrap()
+	.elems;
+
+	let fn_impl = match kind {
+		Kind::Fn => quote! {
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::FnOnce<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(&#name<#(#type_params,)* ()>,I) -> O
+			{
+				type Output = O;
+				#[inline(always)]
+				fn call_once(self, args: I) -> Self::Output {
+					self.f()(&self.set_f(), args)
+				}
+			}
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::FnMut<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(&#name<#(#type_params,)* ()>,I) -> O
+			{
+				#[inline(always)]
+				fn call_mut(&mut self, args: I) -> Self::Output {
+					self.f()(self.set_f_mut(), args)
+				}
+			}
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::Fn<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(&#name<#(#type_params,)* ()>,I) -> O
+			{
+				#[inline(always)]
+				fn call(&self, args: I) -> Self::Output {
+					self.f()(self.set_f_ref(), args)
+				}
+			}
+		},
+		Kind::FnMut => quote! {
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::FnOnce<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(&mut #name<#(#type_params,)* ()>,I) -> O
+			{
+				type Output = O;
+				#[inline(always)]
+				fn call_once(mut self, args: I) -> Self::Output {
+					self.f()(&mut self.set_f(), args)
+				}
+			}
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::FnMut<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(&mut #name<#(#type_params,)* ()>,I) -> O
+			{
+				#[inline(always)]
+				fn call_mut(&mut self, args: I) -> Self::Output {
+					self.f()(self.set_f_mut(), args)
+				}
+			}
+		},
+		Kind::FnOnce => quote! {
+			impl<#(#type_params,)* F, I, O> ::serde_closure::internal::FnOnce<I> for #name<#(#type_params,)* F>
+			where
+				F: ops::FnOnce(#name<#(#type_params,)* ()>,I) -> O
+			{
+				type Output = O;
+				#[inline(always)]
+				fn call_once(self, args: I) -> Self::Output {
+					self.f()(self.set_f(), args)
+				}
+			}
+		},
+	};
+
+	let assert_hack = if cfg!(feature = "assert-hack") {
+		Some(
+			parse2::<Block>(quote! { {
+				const fn size_of_val<T>(t: &T) -> usize {
+					size_of::<T>()
+				}
+				if size_of_val(&closure) != 0 {
+					extern "C" {
+						/// This function doesn't actually exist. It ensures a linking error if it isn't optimized out.
+						pub fn serde_closure_must_explicitly_capture_variable() -> !;
+					}
+					unsafe { serde_closure_must_explicitly_capture_variable() };
+				}
+			} })
+			.unwrap(),
+		)
+	} else {
+		None
+	};
+
+	let serialize_bounds = quote! { #(#type_params: Serialize,)* }.to_string();
+	let deserialize_bounds = quote! { #(#type_params: Deserialize<'de>,)* }.to_string();
+
+	Ok(quote! {
+		{
+			use ::core::{
+				any::type_name,
+				clone::Clone,
+				cmp,
+				cmp::{Eq, Ord, PartialEq, PartialOrd},
+				fmt::{self, Debug},
+				hash,
+				marker::Copy,
+				marker::PhantomData,
+				mem::{self, size_of, MaybeUninit},
+				ops,
+				option::Option::{self, Some},
+				unreachable,
+			};
+			use ::serde::{Deserialize, Serialize};
+			use ::std::{format, panic};
+			fn to_phantom<T>(t: &T) -> PhantomData<fn(T)> {
+				PhantomData
+			}
+			fn is_phantom<T>(t: &T, marker: PhantomData<fn(T)>) {}
+			#[cold]
+			fn panic() -> ! {
+				panic!("A variable with an upper case first letter was implicitly captured.\nUnfortunately due to current limitations it must be captured explicitly.\nPlease refer to the README.");
+			}
+			#[derive(Serialize, Deserialize)]
+			#[serde(
+				bound(serialize = #serialize_bounds),
+				bound(deserialize = #deserialize_bounds)
+			)]
+			struct #name<#(#type_params,)* F> {
+				#( #env_variables: #type_params, )*
+				#[serde(skip)]
+				marker: PhantomData<fn(F)>
+			}
+			impl<#(#type_params,)* F> #name<#(#type_params,)* F> {
+				fn new(#( #env_variables: #type_params, )* _f: F) -> Self {
+					if size_of::<F>() != 0 {
+						panic();
+					}
+					Self{ #( #env_variables ,)* marker: PhantomData }
+				}
+				fn f(&self) -> F {
+					// This is safe as an F has already been materialized (so we
+					// know it isn't uninhabited) and size asserted to be zero.
+					unsafe { MaybeUninit::uninit().assume_init() }
+				}
+				fn set_f_with<F1>(self, _f: F1) -> #name<#(#type_params,)* F1> {
+					if size_of::<F1>() != 0 {
+						panic();
+					}
+					self.set_f()
+				}
+				fn set_f<F1>(self) -> #name<#(#type_params,)* F1> {
+					if size_of::<F1>() != 0 {
+						panic();
+					}
+					#name {
+						#( #env_variables: self.#env_variables, )*
+						marker: PhantomData,
+					}
+				}
+				fn set_f_ref<F1>(&self) -> &#name<#(#type_params,)* F1> {
+					if size_of::<F1>() != 0 {
+						panic();
+					}
+					// This is safe as the size and alignment don't change
+					unsafe { &*(self as *const _ as *const _) }
+				}
+				fn set_f_mut<F1>(&mut self) -> &mut #name<#(#type_params,)* F1> {
+					if size_of::<F1>() != 0 {
+						panic();
+					}
+					// This is safe as the size and alignment don't change
+					unsafe { &mut *(self as *mut _ as *mut _) }
+				}
+			}
+			impl<#(#type_params,)* F> Clone for #name<#(#type_params,)* F>
+			where
+				#(#type_params: Clone,)*
+			{
+				fn clone(&self) -> Self {
+					Self {
+						#( #env_variables: self.#env_variables.clone(), )*
+						marker: PhantomData,
+					}
+				}
+			}
+			impl<#(#type_params,)* F> Copy for #name<#(#type_params,)* F>
+			where
+				#(#type_params: Copy,)*
+			{}
+			impl<#(#type_params,)* F> PartialEq for #name<#(#type_params,)* F>
+			where
+				#(#type_params: PartialEq,)*
+			{
+				fn eq(&self, other: &Self) -> bool {
+					#( self.#env_variables == self.#env_variables && )* true
+				}
+			}
+			impl<#(#type_params,)* F> Eq for #name<#(#type_params,)* F>
+			where
+				#(#type_params: Eq,)*
+			{}
+			impl<#(#type_params,)* F> hash::Hash for #name<#(#type_params,)* F>
+			where
+				#(#type_params: hash::Hash,)*
+			{
+				fn hash<H: hash::Hasher>(&self, state: &mut H) {
+					#( self.#env_variables.hash(state); )*
+				}
+			}
+			impl<#(#type_params,)* F> PartialOrd for #name<#(#type_params,)* F>
+			where
+				#(#type_params: PartialOrd,)*
+			{
+				fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+					let mut ord = Some(cmp::Ordering::Equal);
+					#(
+						ord = if let Some(cmp::Ordering::Equal) = ord {
+							self.#env_variables.partial_cmp(&other.#env_variables)
+						} else { ord };
+					)*
+					ord
+				}
+			}
+			impl<#(#type_params,)* F> Ord for #name<#(#type_params,)* F>
+			where
+				#(#type_params: Ord,)*
+			{
+				fn cmp(&self, other: &Self) -> cmp::Ordering {
+					let mut ord = cmp::Ordering::Equal;
+					#(
+						ord = if let cmp::Ordering::Equal = ord {
+							self.#env_variables.cmp(&other.#env_variables)
+						} else { ord };
+					)*
+					ord
+				}
+			}
+			impl<#(#type_params,)* F> Debug for #name<#(#type_params,)* F>
+			where
+				#(#type_params: Debug,)*
+			{
+				fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+					f.debug_struct(&format!(concat!(stringify!(#name), "<{}>"), type_name::<F>()))
+						#( .field(stringify!(#env_variables), &self.#env_variables) )*
+						.finish()
+				}
+			}
+
+			#fn_impl
+
+			let mut #ret_name = #name::new(#env_capture ());
+			let #env_types_name = to_phantom(&#ret_name);
+			// when impl_trait_in_bindings works could this be const?
+			// https://github.com/rust-lang/rust/issues/55272
+			let closure =
+				#(#attrs)* #asyncness move |mut #env_name: #env_type, (#(#input_pats,)*): (#(#input_types,)*)| #output {
+					if false {
+						is_phantom(& #env_deref, #env_types_name);
+						unreachable!()
+					}
+					#body
+				};
+			if false {
+				#[allow(unreachable_code)]
+				let _ = closure(#ret_ref, unreachable!());
+			}
+
+			#assert_hack
+
+			::serde_closure::#name::internal_new(#ret_name.set_f_with(closure))
+		}
+	})
+}
+
+fn pat_to_type(pat: &Pat) -> Type {
+	match pat {
+		Pat::Type(pat_type) => {
+			if let Type::Infer(_) = *pat_type.ty {
+				pat_to_type(&*pat_type.pat)
+			} else {
+				(*pat_type.ty).clone()
+			}
+		}
+		Pat::Reference(PatReference {
+			and_token,
+			mutability,
+			pat,
+			..
+		}) => Type::Reference(TypeReference {
+			and_token: *and_token,
+			lifetime: None,
+			mutability: *mutability,
+			elem: Box::new(pat_to_type(pat)),
+		}),
+		_ => Type::Infer(TypeInfer {
+			underscore_token: Default::default(),
+		}),
+	}
+}
+
+fn do_pat(
+	pat: &mut Pat, variables: &mut HashSet<Ident>, env_variables: &mut HashSet<Ident>, deref: bool,
+	env_name: &Ident,
+) {
+	match pat {
+		Pat::Ident(PatIdent { ident, subpat, .. }) => {
+			// declaring a variable
+			assert_ne!(ident, env_name);
+			let _ = variables.insert(ident.clone());
+			if let Some((_, subpat)) = subpat {
+				do_pat(subpat, variables, env_variables, deref, env_name);
+			}
+		}
+		Pat::Box(PatBox { pat, .. })
+		| Pat::Reference(PatReference { pat, .. })
+		| Pat::Type(PatType { pat, .. }) => do_pat(&mut *pat, variables, env_variables, deref, env_name),
+		Pat::Or(pat_or) => {
+			for case in &mut pat_or.cases {
+				do_pat(case, variables, env_variables, deref, env_name)
+			}
+		}
+		Pat::Slice(PatSlice { elems, .. })
+		| Pat::Tuple(PatTuple { elems, .. })
+		| Pat::TupleStruct(PatTupleStruct {
+			pat: PatTuple { elems, .. },
+			..
+		}) => {
+			for elem in elems {
+				do_pat(elem, variables, env_variables, deref, env_name)
+			}
+		}
+		Pat::Range(pat_range) => {
+			do_expr(&mut pat_range.lo, variables, env_variables, deref, env_name);
+			do_expr(&mut pat_range.hi, variables, env_variables, deref, env_name);
+		}
+		Pat::Struct(pat_struct) => {
+			for field in &mut pat_struct.fields {
+				do_pat(&mut *field.pat, variables, env_variables, deref, env_name)
+			}
+		}
+		_ => (),
+	}
+}
+
+fn do_block(
+	stmts: &mut [Stmt], variables: &mut HashSet<Ident>, env_variables: &mut HashSet<Ident>,
+	deref: bool, env_name: &Ident,
+) {
+	for stmt in stmts {
+		match stmt {
+			Stmt::Local(Local { pat, init, .. }) => {
+				if let Some((_, expr)) = init {
+					do_expr(expr, variables, env_variables, deref, env_name);
+				}
+				do_pat(pat, variables, env_variables, deref, env_name);
+			}
+			Stmt::Expr(expr) | Stmt::Semi(expr, _) => {
+				do_expr(expr, variables, env_variables, deref, env_name);
+			}
+			Stmt::Item(_) => (),
+		}
+	}
+}
+
+fn do_expr(
+	expr: &mut Expr, variables: &mut HashSet<Ident>, env_variables: &mut HashSet<Ident>,
+	deref: bool, env_name: &Ident,
+) {
+	match expr {
+		Expr::Array(ExprArray { elems, .. }) | Expr::Tuple(ExprTuple { elems, .. }) => {
+			for elem in elems {
+				do_expr(elem, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::Assign(ExprAssign { left, right, .. })
+		| Expr::AssignOp(ExprAssignOp { left, right, .. })
+		| Expr::Binary(ExprBinary { left, right, .. })
+		| Expr::Index(ExprIndex {
+			expr: left,
+			index: right,
+			..
+		})
+		| Expr::Repeat(ExprRepeat {
+			expr: left,
+			len: right,
+			..
+		}) => {
+			do_expr(left, variables, env_variables, deref, env_name);
+			do_expr(right, variables, env_variables, deref, env_name);
+		}
+		Expr::Async(ExprAsync { block, .. })
+		| Expr::Block(ExprBlock { block, .. })
+		| Expr::Loop(ExprLoop { body: block, .. })
+		| Expr::TryBlock(ExprTryBlock { block, .. })
+		| Expr::Unsafe(ExprUnsafe { block, .. }) => {
+			let variables = &mut variables.clone();
+			do_block(&mut block.stmts, variables, env_variables, deref, env_name);
+		}
+		Expr::Await(ExprAwait { base: expr, .. })
+		| Expr::Box(ExprBox { expr, .. })
+		| Expr::Break(ExprBreak {
+			expr: Some(expr), ..
+		})
+		| Expr::Cast(ExprCast { expr, .. })
+		| Expr::Field(ExprField { base: expr, .. })
+		| Expr::Group(ExprGroup { expr, .. })
+		| Expr::Paren(ExprParen { expr, .. })
+		| Expr::Reference(ExprReference { expr, .. })
+		| Expr::Return(ExprReturn {
+			expr: Some(expr), ..
+		})
+		| Expr::Try(ExprTry { expr, .. })
+		| Expr::Type(ExprType { expr, .. })
+		| Expr::Unary(ExprUnary { expr, .. })
+		| Expr::Yield(ExprYield {
+			expr: Some(expr), ..
+		}) => {
+			do_expr(expr, variables, env_variables, deref, env_name);
+		}
+		Expr::Call(ExprCall {
+			func: receiver,
+			args,
+			..
+		})
+		| Expr::MethodCall(ExprMethodCall { receiver, args, .. }) => {
+			do_expr(receiver, variables, env_variables, deref, env_name);
+			for arg in args {
+				do_expr(arg, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::Closure(ExprClosure { inputs, body, .. }) => {
+			let variables = &mut variables.clone();
+			for input in inputs {
+				do_pat(input, variables, env_variables, deref, env_name);
+			}
+			do_expr(body, variables, env_variables, deref, env_name);
+		}
+		Expr::ForLoop(ExprForLoop {
+			pat, expr, body, ..
+		}) => {
+			do_expr(expr, variables, env_variables, deref, env_name);
+			let variables = &mut variables.clone();
+			do_pat(pat, variables, env_variables, deref, env_name);
+			do_block(&mut body.stmts, variables, env_variables, deref, env_name);
+		}
+		Expr::If(ExprIf {
+			cond,
+			then_branch,
+			else_branch,
+			..
+		}) => {
+			{
+				let variables = &mut variables.clone();
+				do_expr(cond, variables, env_variables, deref, env_name);
+				do_block(
+					&mut then_branch.stmts,
+					variables,
+					env_variables,
+					deref,
+					env_name,
+				);
+			}
+			if let Some((_, else_branch)) = else_branch {
+				do_expr(else_branch, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::Let(ExprLet { pat, expr, .. }) => {
+			do_expr(expr, variables, env_variables, deref, env_name);
+			do_pat(pat, variables, env_variables, deref, env_name);
+		}
+		Expr::Match(ExprMatch { expr, arms, .. }) => {
+			do_expr(expr, variables, env_variables, deref, env_name);
+			for Arm {
+				pat, guard, body, ..
+			} in arms
+			{
+				let variables = &mut variables.clone();
+				do_pat(pat, variables, env_variables, deref, env_name);
+				if let Some((_, guard)) = guard {
+					do_expr(guard, variables, env_variables, deref, env_name);
+				}
+				do_expr(body, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::Path(ExprPath { path, .. }) if path.get_ident().is_some() => {
+			let ident = path.get_ident().unwrap();
+			// We can't distinguish variables from types that are values, like unit/tuple
+			// structs/enum variants and functions. Use the case of the first char as a heuristic.
+			if !ident.to_string().chars().next().unwrap().is_uppercase() {
+				// referencing a variable
+				if !variables.contains(ident) {
+					let _ = env_variables.insert(ident.clone());
+					let mut a = Expr::Field(ExprField {
+						attrs: vec![],
+						base: Box::new(Expr::Path(ExprPath {
+							attrs: vec![],
+							qself: None,
+							path: Path {
+								leading_colon: None,
+								segments: iter::once(PathSegment {
+									ident: env_name.clone(),
+									arguments: PathArguments::None,
+								})
+								.collect(),
+							},
+						})),
+						dot_token: Default::default(),
+						member: Member::Named(ident.clone()),
+					});
+					if deref {
+						a = Expr::Unary(ExprUnary {
+							attrs: vec![],
+							op: UnOp::Deref(Default::default()),
+							expr: Box::new(a),
+						});
+					}
+					*expr = Expr::Paren(ExprParen {
+						attrs: vec![],
+						paren_token: Default::default(),
+						expr: Box::new(a),
+					});
+				}
+			}
+		}
+		Expr::Range(ExprRange { from, to, .. }) => {
+			if let Some(from) = from {
+				do_expr(from, variables, env_variables, deref, env_name);
+			}
+			if let Some(to) = to {
+				do_expr(to, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::Struct(ExprStruct { fields, rest, .. }) => {
+			for FieldValue { expr, .. } in fields {
+				do_expr(expr, variables, env_variables, deref, env_name);
+			}
+			if let Some(rest) = rest {
+				do_expr(rest, variables, env_variables, deref, env_name);
+			}
+		}
+		Expr::While(ExprWhile { cond, body, .. }) => {
+			let variables = &mut variables.clone();
+			do_expr(cond, variables, env_variables, deref, env_name);
+			do_block(&mut body.stmts, variables, env_variables, deref, env_name);
+		}
+		_ => (),
+	}
+}
+
+#[inline(always)]
+fn alpha(u: u8) -> u8 {
+	assert!(u < 26);
+	u + b'A'
+}
+const BUF_SIZE: usize = 64; // u64::max_value() in base 2
+fn bijective_base(n: u64, base: u64, digits: impl Fn(u8) -> u8) -> String {
+	let mut buffer = [0_u8; BUF_SIZE];
+	let divided = successors(Some(n), |n| match n / base {
+		0 => None,
+		n => Some(n - 1),
+	});
+	#[allow(clippy::suspicious_map)]
+	let written = buffer
+		.iter_mut()
+		.rev()
+		.zip(divided)
+		.map(|(c, n)| *c = digits((n % base) as u8))
+		.count();
+	let index = BUF_SIZE - written;
+
+	unsafe { std::str::from_utf8_unchecked(&buffer[index..]) }.to_owned()
+}
+
+#[test]
+fn bijective_base_test() {
+	for i in 0..=26 + 26 * 26 + 26 * 26 * 26 {
+		let _ = bijective_base(i, 26, alpha);
+	}
+	assert_eq!(
+		bijective_base(26 + 26 * 26 + 26 * 26 * 26, 26, alpha),
+		"AAAA"
+	);
+	assert_eq!(
+		bijective_base(u64::max_value(), 3, alpha),
+		"AAAABBABCBBABBAABCCAACCCACAACACCACCBAABBA"
+	);
+	assert_eq!(
+		bijective_base(u64::max_value(), 2, alpha),
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB"
+	);
+}

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -9,7 +9,7 @@
 //! See [`serde_closure`](https://docs.rs/serde_closure/) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.0")]
 #![allow(non_snake_case)] // due to proc-macro-hack can't apply this directly
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@
 //! # 	type Item = I::Item;
 //! # }
 //! fn sum_of_squares(input: &[i32]) -> i32 {
-//! 	input.dist_iter()
-//! 		.map(Fn!(|&i| i * i))
-//! 		.sum()
+//!     input.dist_iter()
+//!         .map(Fn!(|&i| i * i))
+//!         .sum()
 //! }
 //! ```
 //!
@@ -66,20 +66,19 @@
 //! running on each of a cluster of machines, this library would help you to
 //! send closures between them.
 //!
-//! This library aims to work in as simple and un-magical a way as possible. It
-//! currently requires nightly Rust for the `unboxed_closures` and `fn_traits`
-//! features (rust issue
+//! This library aims to work in as simple, safe and un-magical a way as
+//! possible. It currently requires nightly Rust for the `unboxed_closures` and
+//! `fn_traits` features (rust issue
 //! [#29625](https://github.com/rust-lang/rust/issues/29625)).
 //!
-//!  * There are three macros, [`FnOnce`](macro@FnOnce), [`FnMut`](macro@FnMut) and
-//! [`Fn`](macro@Fn), corresponding to the three types of Rust closure.
-//!  * The *captured variables*, i.e. those variables that are referenced by the
-//! closure but are declared outside of it, must be explicitly listed.
-//!  * There are currently some minor limitations of syntax over normal closure
-//! syntax, which are documented below.
-//!  * The closure is coerced to a function pointer, which is wrapped by
-//! [relative::Code](https://docs.rs/relative) such that it can safely be
-//! sent between processes.
+//!  * There are three macros, [`FnOnce`](macro@FnOnce), [`FnMut`](macro@FnMut)
+//!    and [`Fn`](macro@Fn), corresponding to the three types of Rust closure.
+//!  * Wrap your closure with one of the macros and it will now implement
+//!    `Copy`, `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`,
+//!    `Serialize`, `Deserialize` and `Debug`.
+//!  * There are some minor syntax limitations, which are documented below.
+//!  * This crate has one unavoidable but documented and sound usage of
+//!    `unsafe`.
 //!
 //! # Examples of wrapped closures
 //! **Inferred, non-capturing closure:**
@@ -122,11 +121,9 @@
 //! # #[macro_use] extern crate serde_closure;
 //! let mut num = 0;
 //! # (
-//! FnMut!([num] |a| *num += a)
+//! FnMut!(|a| num += a)
 //! # )(1i32);
 //! ```
-//! Note: As this is a FnMut closure, `num` is a mutable reference, and must be
-//! dereferenced to use.
 //!
 //! **`move` closure, capturing `hello` and `world`:**
 //! ```
@@ -135,7 +132,7 @@
 //! let mut world = String::new();
 //! # (
 //! move |name| {
-//! 	world += (hello.to_uppercase() + name).as_str();
+//!     world += (hello.to_uppercase() + name).as_str();
 //! }
 //! # )("abc");
 //! ```
@@ -144,28 +141,54 @@
 //! let hello = String::from("hello");
 //! let mut world = String::new();
 //! # (
-//! FnMut!([hello, world] move |name| {
-//! 	*world += (hello.to_uppercase() + name).as_str();
+//! FnMut!(move |name| {
+//!     world += (hello.to_uppercase() + name).as_str();
 //! })
 //! # )("abc");
 //! ```
-//! Note: `world` must be dereferenced to use.
 //!
-//! # Cosmetic limitations
-//! As visible above, there are currently some minor limitations:
-//!  * The captured variables in FnMut and Fn closures are references, so need
-//! to be dereferenced;
-//!  * Compiler errors are not as helpful as normal:
+//! # Limitations
+//! There are currently some minor limitations:
+//!  * Captured variables with an uppercase first letter need to be explicitly
+//!    captured. If you see a panic like the following, fix the case of the
+//!    variable.
 //! ```text
-//! error[E0308]: mismatched types
-//! ...
-//!    = note: expected type `for<..> fn(&'r mut (..), (..))`
-//!               found type `[closure@<FnMut macros>:9:9: 10:44 my_var:_]`
+//! thread 'main' panicked at 'A variable with an upper case first letter was implicitly captured.
+//! Unfortunately due to current limitations it must be captured explicitly.
+//! Please refer to the README.', tests/test.rs:205:10
+//! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 //! ```
-//! means that `my_var` is a captured variable, but was not explicitly listed.
+//!  * Functions called inside the closure might need to be disambiguated. This
+//!    also affects enum unit and tuple variants with a lowercase first letter.
+//!    If you see an error like either of the following, qualify `my_function`
+//!    as `self::my_function` and `my_enum_variant` as
+//!    `MyEnum::my_enum_variant`.
+//! ```text
+//! error[E0277]: the trait bound `fn(usize) -> std::option::Option<usize> {my_function::<usize>}: fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not satisfied
+//!    --> tests/test.rs:327:10
+//!     |
+//! 314 |     fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
+//!     |        ------
+//! 315 |     where
+//! 316 |         F: Fn(&mut St) -> Option<A> + Serialize,
+//!     |                                       --------- required by this bound in `fnref::unfold`
+//! ...
+//! 327 |     let _ = unfold(0_usize, Fn!(|acc: &mut _| my_function(*acc)));
+//!     |             ^^^^^^ the trait `fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not implemented for `fn(usize) -> std::option::Option<usize> {my_function::<usize>}`
+//! ```
+//! ```text
+//! error[E0530]: function parameters cannot shadow tuple variants
+//!    --> tests/test.rs:173:47
+//!     |
+//! 173 |     FnMut!(|acc: &mut _| my_enum_variant(*acc))
+//!     |     ---------------------^^^^^^^^^^^^^^^-------
+//!     |     |                    |
+//!     |     |                    cannot be named the same as a tuple variant
+//!     |     in this macro invocation
+//! ```
 
 #![doc(html_root_url = "https://docs.rs/serde_closure/0.1.5")]
-#![feature(unboxed_closures, fn_traits, core_intrinsics)]
+#![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,
@@ -179,120 +202,137 @@
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
 #![allow(clippy::inline_always)]
 
-use relative::Code;
+use proc_macro_hack::proc_macro_hack;
 use serde::{Deserialize, Serialize};
-use std::{cmp, fmt, hash, intrinsics, marker, mem, ops};
+use std::fmt::{self, Debug};
+
+/// Macro that wraps a closure, evaluating to a [`FnOnce`](struct@FnOnce) struct
+/// that implements [`std::ops::FnOnce`], serde's [`Serialize`] and
+/// [`Deserialize`], and various convenience traits.
+///
+/// See the [readme](self) for examples.
+#[proc_macro_hack(fake_call_site)]
+pub use serde_closure_derive::FnOnce;
+
+/// Macro that wraps a closure, evaluating to a [`FnMut`](struct@FnMut) struct
+/// that implements [`std::ops::FnMut`], serde's [`Serialize`] and
+/// [`Deserialize`], and various convenience traits.
+///
+/// See the [readme](self) for examples.
+#[proc_macro_hack(fake_call_site)]
+pub use serde_closure_derive::FnMut;
+
+/// Macro that wraps a closure, evaluating to a [`Fn`](struct@Fn) struct that
+/// implements [`std::ops::Fn`], serde's [`Serialize`] and
+/// [`Deserialize`], and various convenience traits.
+///
+/// See the [readme](self) for examples.
+#[proc_macro_hack(fake_call_site)]
+pub use serde_closure_derive::Fn;
+
+#[doc(hidden)]
+pub mod internal {
+	use std::ops;
+
+	pub trait FnOnce<Args> {
+		type Output;
+
+		fn call_once(self, args: Args) -> Self::Output;
+	}
+	pub trait FnMut<Args>: FnOnce<Args> {
+		fn call_mut(&mut self, args: Args) -> Self::Output;
+	}
+	pub trait Fn<Args>: FnMut<Args> {
+		fn call(&self, args: Args) -> Self::Output;
+	}
+
+	impl<F, I> ops::FnOnce<I> for super::FnOnce<F>
+	where
+		F: FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		extern "rust-call" fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+
+	impl<F, I> ops::FnOnce<I> for super::FnMut<F>
+	where
+		F: FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		extern "rust-call" fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+	impl<F, I> ops::FnMut<I> for super::FnMut<F>
+	where
+		F: FnMut<I>,
+	{
+		#[inline(always)]
+		extern "rust-call" fn call_mut(&mut self, args: I) -> Self::Output {
+			self.f.call_mut(args)
+		}
+	}
+
+	impl<F, I> ops::FnOnce<I> for super::Fn<F>
+	where
+		F: FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		extern "rust-call" fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+	impl<F, I> ops::FnMut<I> for super::Fn<F>
+	where
+		F: FnMut<I>,
+	{
+		#[inline(always)]
+		extern "rust-call" fn call_mut(&mut self, args: I) -> Self::Output {
+			self.f.call_mut(args)
+		}
+	}
+	impl<F, I> ops::Fn<I> for super::Fn<F>
+	where
+		F: Fn<I>,
+	{
+		#[inline(always)]
+		extern "rust-call" fn call(&self, args: I) -> Self::Output {
+			self.f.call(args)
+		}
+	}
+}
 
 /// A struct representing a serializable closure, created by the
 /// [`FnOnce`](macro@FnOnce) macro. Implements [`std::ops::FnOnce`], serde's [`Serialize`] and
 /// [`Deserialize`], and various convenience traits.
 ///
-/// It is generic over `E`: a tuple of the environment variables passed to the
-/// [`FnOnce`](macro@FnOnce) macro; and `F`: the signature of closure as coerced
-/// to a function pointer.
-///
 /// See the [readme](self) for examples.
-#[derive(Serialize, Deserialize)]
-#[serde(
-	bound(serialize = "E: Serialize, F: 'static"),
-	bound(deserialize = "E: Deserialize<'de>, F: 'static")
-)]
-pub struct FnOnce<E, F> {
-	env: E,
-	addr: Code<F>,
-	#[serde(skip)]
-	marker: marker::PhantomData<F>,
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FnOnce<F> {
+	f: F,
 }
-impl<E, F> FnOnce<E, F> {
+impl<F> FnOnce<F> {
+	/// Internal method
 	#[doc(hidden)]
-	#[inline(always)]
-	/// Fn pointers from coerced closures will, bar an extremely odd turn of
-	/// events, point into the same segment as the base used by
-	/// [relative::Code], thus upholding [relative::Code::from()]'s unsafe
-	/// contract.
-	pub unsafe fn private_construct(env: E, addr: *const (), _: &F) -> Self {
-		Self {
-			env,
-			addr: Code::from(addr),
-			marker: marker::PhantomData,
-		}
+	pub fn internal_new<I>(f: F) -> Self
+	where
+		F: internal::FnOnce<I>,
+	{
+		Self { f }
 	}
 }
-impl<E, T, F, O> ops::FnOnce<T> for FnOnce<E, F>
+impl<F> Debug for FnOnce<F>
 where
-	F: ops::FnOnce(E, T) -> O,
+	F: Debug,
 {
-	type Output = O;
-	#[inline(always)]
-	extern "rust-call" fn call_once(self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(E, T) -> F::Output>(self.addr.to()) }
-			.call_once((self.env, args))
-	}
-}
-impl<E, T> Clone for FnOnce<E, T>
-where
-	E: Clone,
-{
-	fn clone(&self) -> Self {
-		Self {
-			env: self.env.clone(),
-			addr: self.addr,
-			marker: marker::PhantomData,
-		}
-	}
-}
-impl<E, T> Copy for FnOnce<E, T> where E: Copy {}
-impl<E, T> PartialEq for FnOnce<E, T>
-where
-	E: PartialEq,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.env == other.env && self.addr == other.addr
-	}
-}
-impl<E, T> Eq for FnOnce<E, T> where E: Eq {}
-impl<E, T> hash::Hash for FnOnce<E, T>
-where
-	E: hash::Hash,
-{
-	fn hash<H: hash::Hasher>(&self, state: &mut H) {
-		self.env.hash(state);
-		self.addr.hash(state);
-	}
-}
-impl<E, T> PartialOrd for FnOnce<E, T>
-where
-	E: PartialOrd,
-{
-	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-		self.env
-			.partial_cmp(&other.env)
-			.map(|x| x.then_with(|| self.addr.cmp(&other.addr)))
-	}
-}
-impl<E, T> Ord for FnOnce<E, T>
-where
-	E: Ord,
-{
-	fn cmp(&self, other: &Self) -> cmp::Ordering {
-		self.env
-			.cmp(&other.env)
-			.then_with(|| self.addr.cmp(&other.addr))
-	}
-}
-impl<E, T> fmt::Debug for FnOnce<E, T>
-where
-	E: fmt::Debug,
-{
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt.debug_struct("FnOnce")
-			.field("env", &self.env)
-			.field(unsafe { intrinsics::type_name::<T>() }, &self.addr)
-			.finish()
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		Debug::fmt(&self.f, f)
 	}
 }
 
@@ -300,126 +340,28 @@ where
 /// [`FnMut`](macro@FnMut) macro. Implements [`std::ops::FnMut`], serde's [`Serialize`] and
 /// [`Deserialize`], and various convenience traits.
 ///
-/// It is generic over `E`: a tuple of the environment variables passed to the
-/// [`FnMut`](macro@FnMut) macro; and `F`: the signature of closure as coerced to
-/// a function pointer.
-///
 /// See the [readme](self) for examples.
-#[derive(Serialize, Deserialize)]
-#[serde(
-	bound(serialize = "E: Serialize, F: 'static"),
-	bound(deserialize = "E: Deserialize<'de>, F: 'static")
-)]
-pub struct FnMut<E, F> {
-	env: E,
-	addr: Code<F>,
-	#[serde(skip)]
-	marker: marker::PhantomData<F>,
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FnMut<F> {
+	f: F,
 }
-impl<E, F> FnMut<E, F> {
+impl<F> FnMut<F> {
+	/// Internal method
 	#[doc(hidden)]
-	#[inline(always)]
-	/// Fn pointers from coerced closures will, bar an extremely odd turn of
-	/// events, point into the same segment as the base used by
-	/// [relative::Code], thus upholding [relative::Code::from()]'s unsafe
-	/// contract.
-	pub unsafe fn private_construct(env: E, addr: *const (), _: &F) -> Self {
-		Self {
-			env,
-			addr: Code::from(addr),
-			marker: marker::PhantomData,
-		}
+	pub fn internal_new<I>(f: F) -> Self
+	where
+		F: internal::FnMut<I>,
+	{
+		Self { f }
 	}
 }
-impl<E, T, F, O> ops::FnOnce<T> for FnMut<E, F>
+impl<F> Debug for FnMut<F>
 where
-	F: ops::FnOnce(&mut E, T) -> O,
+	F: Debug,
 {
-	type Output = O;
-	#[inline(always)]
-	extern "rust-call" fn call_once(mut self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(&mut E, T) -> F::Output>(self.addr.to()) }
-			.call_once((&mut self.env, args))
-	}
-}
-impl<E, T, F, O> ops::FnMut<T> for FnMut<E, F>
-where
-	F: ops::FnOnce(&mut E, T) -> O,
-{
-	#[inline(always)]
-	extern "rust-call" fn call_mut(&mut self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(&mut E, T) -> F::Output>(self.addr.to()) }
-			.call_mut((&mut self.env, args))
-	}
-}
-impl<E, T> Clone for FnMut<E, T>
-where
-	E: Clone,
-{
-	fn clone(&self) -> Self {
-		Self {
-			env: self.env.clone(),
-			addr: self.addr,
-			marker: marker::PhantomData,
-		}
-	}
-}
-impl<E, T> Copy for FnMut<E, T> where E: Copy {}
-impl<E, T> PartialEq for FnMut<E, T>
-where
-	E: PartialEq,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.env == other.env && self.addr == other.addr
-	}
-}
-impl<E, T> Eq for FnMut<E, T> where E: Eq {}
-impl<E, T> hash::Hash for FnMut<E, T>
-where
-	E: hash::Hash,
-{
-	fn hash<H: hash::Hasher>(&self, state: &mut H) {
-		self.env.hash(state);
-		self.addr.hash(state);
-	}
-}
-impl<E, T> PartialOrd for FnMut<E, T>
-where
-	E: PartialOrd,
-{
-	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-		self.env
-			.partial_cmp(&other.env)
-			.map(|x| x.then_with(|| self.addr.cmp(&other.addr)))
-	}
-}
-impl<E, T> Ord for FnMut<E, T>
-where
-	E: Ord,
-{
-	fn cmp(&self, other: &Self) -> cmp::Ordering {
-		self.env
-			.cmp(&other.env)
-			.then_with(|| self.addr.cmp(&other.addr))
-	}
-}
-impl<E, T> fmt::Debug for FnMut<E, T>
-where
-	E: fmt::Debug,
-{
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt.debug_struct("FnMut")
-			.field("env", &self.env)
-			.field(unsafe { intrinsics::type_name::<T>() }, &self.addr)
-			.finish()
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		Debug::fmt(&self.f, f)
 	}
 }
 
@@ -428,788 +370,27 @@ where
 /// and [`Deserialize`], and various convenience
 /// traits.
 ///
-/// It is generic over `E`: a tuple of the environment variables passed to the
-/// [`Fn`](macro@Fn) macro; and `F`: the signature of closure as coerced to a
-/// function pointer.
-///
 /// See the [readme](self) for examples.
-#[derive(Serialize, Deserialize)]
-#[serde(
-	bound(serialize = "E: Serialize, F: 'static"),
-	bound(deserialize = "E: Deserialize<'de>, F: 'static")
-)]
-pub struct Fn<E, F> {
-	env: E,
-	addr: Code<F>,
-	#[serde(skip)]
-	marker: marker::PhantomData<F>,
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Fn<F> {
+	f: F,
 }
-impl<E, F> Fn<E, F> {
+impl<F> Fn<F> {
+	/// Internal method
 	#[doc(hidden)]
-	#[inline(always)]
-	/// Fn pointers from coerced closures will, bar an extremely odd turn of
-	/// events, point into the same segment as the base used by
-	/// [relative::Code], thus upholding [relative::Code::from()]'s unsafe
-	/// contract.
-	pub unsafe fn private_construct(env: E, addr: *const (), _: &F) -> Self {
-		Self {
-			env,
-			addr: Code::from(addr),
-			marker: marker::PhantomData,
-		}
+	pub fn internal_new<I>(f: F) -> Self
+	where
+		F: internal::Fn<I>,
+	{
+		Self { f }
 	}
 }
-impl<E, T, F, O> ops::FnOnce<T> for Fn<E, F>
+impl<F> Debug for Fn<F>
 where
-	F: ops::FnOnce(&E, T) -> O,
+	F: Debug,
 {
-	type Output = O;
-	#[inline(always)]
-	extern "rust-call" fn call_once(self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(&E, T) -> F::Output>(self.addr.to()) }
-			.call_once((&self.env, args))
-	}
-}
-impl<E, T, F, O> ops::FnMut<T> for Fn<E, F>
-where
-	F: ops::FnOnce(&E, T) -> O,
-{
-	#[inline(always)]
-	extern "rust-call" fn call_mut(&mut self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(&E, T) -> F::Output>(self.addr.to()) }
-			.call_mut((&self.env, args))
-	}
-}
-impl<E, T, F, O> ops::Fn<T> for Fn<E, F>
-where
-	F: ops::FnOnce(&E, T) -> O,
-{
-	#[inline(always)]
-	extern "rust-call" fn call(&self, args: T) -> Self::Output {
-		// This is fine *as long as* private_construct is given the same fn pointer in last 2 args.
-		// This is always true for what should be the only caller: the macro.
-		// This seems necessary to avoid bounding the lifetimes of the fn arguments, which reduces
-		// the utility substantially.
-		unsafe { mem::transmute::<*const (), fn(&E, T) -> F::Output>(self.addr.to()) }
-			.call((&self.env, args))
-	}
-}
-impl<E, T> Clone for Fn<E, T>
-where
-	E: Clone,
-{
-	fn clone(&self) -> Self {
-		Self {
-			env: self.env.clone(),
-			addr: self.addr,
-			marker: marker::PhantomData,
-		}
-	}
-}
-impl<E, T> Copy for Fn<E, T> where E: Copy {}
-impl<E, T> PartialEq for Fn<E, T>
-where
-	E: PartialEq,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.env == other.env && self.addr == other.addr
-	}
-}
-impl<E, T> Eq for Fn<E, T> where E: Eq {}
-impl<E, T> hash::Hash for Fn<E, T>
-where
-	E: hash::Hash,
-{
-	fn hash<H: hash::Hasher>(&self, state: &mut H) {
-		self.env.hash(state);
-		self.addr.hash(state);
-	}
-}
-impl<E, T> PartialOrd for Fn<E, T>
-where
-	E: PartialOrd,
-{
-	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-		self.env
-			.partial_cmp(&other.env)
-			.map(|x| x.then_with(|| self.addr.cmp(&other.addr)))
-	}
-}
-impl<E, T> Ord for Fn<E, T>
-where
-	E: Ord,
-{
-	fn cmp(&self, other: &Self) -> cmp::Ordering {
-		self.env
-			.cmp(&other.env)
-			.then_with(|| self.addr.cmp(&other.addr))
-	}
-}
-impl<E, T> fmt::Debug for Fn<E, T>
-where
-	E: fmt::Debug,
-{
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt.debug_struct("Fn")
-			.field("env", &self.env)
-			.field(unsafe { intrinsics::type_name::<T>() }, &self.addr)
-			.finish()
-	}
-}
-
-/// Macro that wraps a closure, evaluating to a [`FnOnce`](struct@FnOnce) struct
-/// that implements [`std::ops::FnOnce`], serde's [`Serialize`] and
-/// [`Deserialize`], and various convenience traits.
-///
-/// See the [readme](self) for examples.
-#[macro_export]
-macro_rules! FnOnce {
-	([$( $env:ident ,)* ] move |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let env = ($($env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(E,($($u,)*))->O) -> fn(E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, move|($($env,)*),($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(env,unreachable!());
-		}
-		let fn_ptr: fn(_,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::FnOnce::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-	([$( $env:ident ,)* ] ref |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let env = ($(&$env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(E,($($u,)*))->O) -> fn(E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, |($($env,)*),($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(env,unreachable!());
-		}
-		let fn_ptr: fn(_,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::FnOnce::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty, $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || $block:expr) => { $crate::FnOnce!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> _ { $block } ) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || -> $o:ty $block:block) => { $crate::FnOnce!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> $o $block ) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| () |$( $tail:tt )*) => { compile_error!("This macro unfortunately only handles up to 32 arguments. Easily extendable, fork and bump it if you really need that many!") };
-
-	([$( $env:ident ),* $(,)* ] move | $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(move | $( $tail:tt )*) => { $crate::FnOnce!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] move || $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(move || $( $tail:tt )*) => { $crate::FnOnce!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] | $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(| $( $tail:tt )*) => { $crate::FnOnce!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] || $( $tail:tt )*) => { $crate::FnOnce!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(|| $( $tail:tt )*) => { $crate::FnOnce!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-}
-
-/// Macro that wraps a closure, evaluating to a [`FnMut`](struct@FnMut) struct
-/// that implements [`std::ops::FnMut`], serde's [`Serialize`] and
-/// [`Deserialize`], and various convenience traits.
-///
-/// See the [readme](self) for examples.
-#[macro_export]
-macro_rules! FnMut {
-	([$( $env:ident ,)* ] move |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let mut env = ($($env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(&mut E,($($u,)*))->O) -> fn(&mut E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, move|&mut ($(ref mut $env,)*):&mut _,($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(&mut env,unreachable!());
-		}
-		let fn_ptr: fn(&mut _,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(&mut env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::FnMut::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-	([$( $env:ident ,)* ] ref |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let mut env = ($(&mut $env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(&mut E,($($u,)*))->O) -> fn(&mut E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, |&mut ($(&mut ref mut $env,)*):&mut _,($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(&mut env,unreachable!());
-		}
-		let fn_ptr: fn(&mut _,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(&mut env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::FnMut::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty, $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty $(,)*| $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || $block:expr) => { $crate::FnMut!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> _ { $block } ) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || -> $o:ty $block:block) => { $crate::FnMut!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> $o $block ) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| () |$( $tail:tt )*) => { compile_error!("This macro unfortunately only handles up to 32 arguments. Easily extendable, fork and bump it if you really need that many!") };
-
-	([$( $env:ident ),* $(,)* ] move | $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(move | $( $tail:tt )*) => { $crate::FnMut!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] move || $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(move || $( $tail:tt )*) => { $crate::FnMut!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] | $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(| $( $tail:tt )*) => { $crate::FnMut!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] || $( $tail:tt )*) => { $crate::FnMut!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(|| $( $tail:tt )*) => { $crate::FnMut!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-}
-
-/// Macro that wraps a closure, evaluating to a [`Fn`](struct@Fn) struct that
-/// implements [`std::ops::Fn`], serde's [`Serialize`] and
-/// [`Deserialize`], and various convenience traits.
-///
-/// See the [readme](self) for examples.
-#[macro_export]
-macro_rules! Fn {
-	([$( $env:ident ,)* ] move |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let env = ($($env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(&E,($($u,)*))->O) -> fn(&E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, move|&($(ref $env,)*):&_,($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(&env,unreachable!());
-		}
-		let fn_ptr: fn(&_,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(&env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::Fn::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-	([$( $env:ident ,)* ] ref |$( $arg:pat => $ty:ty, $t:ident $u:ty,)*| -> $o:ty $block:block) => ({
-		let env = ($(&$env,)*);
-		fn apply_env_type<E,O,$($t,)*>(_ :&E, f: fn(&E,($($u,)*))->O) -> fn(&E,($($u,)*))->O {f}
-		let closure = apply_env_type(&env, |&($($env,)*):&_,($($arg,)*):($($ty,)*)|->$o { $block });
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = closure(&env,unreachable!());
-		}
-		let fn_ptr: fn(&_,($($ty,)*))->$o = closure;
-		if false {
-			#[allow(unreachable_code)]
-			let _: $o = fn_ptr(&env,unreachable!());
-		}
-		#[allow(unused_unsafe)]
-		unsafe {
-			$crate::Fn::private_construct(
-				env,
-				fn_ptr as *const (),
-				&fn_ptr,
-			)
-		}
-	});
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty, $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) | $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => &mut _, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:pat $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => &_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => _, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |&mut $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* &mut $arg_ => $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |& $arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* & $arg_ => $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: &mut $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => &mut $type_, $s &mut $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: & $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => & $type_, $s & $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:ident: $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($s:ident $($ss:ident)*) |$arg_:pat=> $type_:ty $(,)*| $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] $move |$($arg => $type,$t $u,)* $arg_ => $type_, $s $s,| ($($ss)*) || $( $tail )*) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || $block:expr) => { $crate::Fn!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> _ { $block } ) };
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| ($($ss:ident)*) || -> $o:ty $block:block) => { $crate::Fn!([$($env,)*] $move |$($arg => $type,$t $u,)*| -> $o $block ) };
-
-	(@args [$( $env:ident ,)* ] $move:ident |$( $arg:pat => $type:ty, $t:ident $u:ty,)*| () |$( $tail:tt )*) => { compile_error!("This macro unfortunately only handles up to 32 arguments. Easily extendable, fork and bump it if you really need that many!") };
-
-	([$( $env:ident ),* $(,)* ] move | $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(move | $( $tail:tt )*) => { $crate::Fn!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] move || $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(move || $( $tail:tt )*) => { $crate::Fn!(@args [] move | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] | $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	(| $( $tail:tt )*) => { $crate::Fn!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) | $( $tail )*) };
-	([$( $env:ident ),* $(,)* ] || $( $tail:tt )*) => { $crate::Fn!(@args [$($env,)*] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-	(|| $( $tail:tt )*) => { $crate::Fn!(@args [] ref | | (T0 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24 T25 T26 T27 T28 T29 T30 T31 T32) || $( $tail )*) };
-}
-
-#[cfg(test)]
-mod tests {
-	#![allow(clippy::items_after_statements, clippy::type_complexity)]
-	use bincode;
-	use serde::{de::DeserializeOwned, Serialize};
-	use serde_json;
-	use std::{env, fmt, mem, process, str};
-	#[test]
-	fn fn_ptr_size() {
-		assert_eq!(mem::size_of::<usize>(), mem::size_of::<fn()>());
-	}
-	#[test]
-	fn fnonce() {
-		fn test<
-			F: FnOnce(usize, &usize, &mut usize, String, &String, &mut String) -> String
-				+ Serialize
-				+ DeserializeOwned
-				+ PartialEq
-				+ Eq
-				+ Clone
-				+ fmt::Debug,
-		>(
-			f: F,
-		) {
-			let deserialized: F =
-				serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
-			let deserialized2: F = bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
-			assert_eq!(f, deserialized);
-			assert_eq!(deserialized, deserialized2);
-			assert_eq!(f, deserialized2);
-			let test = |f: F| {
-				let mut a = 3;
-				let mut b = String::from("ghi");
-				assert_eq!(
-					f.clone()(
-						1,
-						&2,
-						&mut a,
-						String::from("abc"),
-						&String::from("def"),
-						&mut b
-					),
-					"3qwerty129abcdefghiqwertyabcdef"
-				);
-				a += 6;
-				b += "pqr";
-				assert_eq!(
-					f.clone()(
-						4,
-						&5,
-						&mut a,
-						String::from("jkl"),
-						&String::from("mno"),
-						&mut b
-					),
-					"3qwerty4527jklmnoghiqwertyabcdefpqrqwertyjklmno"
-				);
-				a += 9;
-				b += "yz";
-				assert_eq!(
-					f(
-						7,
-						&8,
-						&mut a,
-						String::from("stu"),
-						&String::from("vwx"),
-						&mut b
-					),
-					"3qwerty7854stuvwxghiqwertyabcdefpqrqwertyjklmnoyzqwertystuvwx"
-				);
-			};
-			test(f);
-			test(deserialized);
-			test(deserialized2);
-		}
-		let (a, b) = (3_usize, String::from("qwerty"));
-		let a = FnOnce!([a,b] move |c,d:&_,e:&mut _,f:String,g:&String,h:&mut String| -> String {
-			let a: usize = a;
-			let b: String = b;
-			*e += a+c+*d;
-			// *a += *e;
-			*h += (b.clone()+f.as_str()+g.as_str()).as_str();
-			// *b += h.as_str();
-			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
-		});
-		test(a);
-		let b = FnOnce!(|a| {
-			println!("{:?}", a);
-		});
-		b(0_usize);
-		let c = FnOnce!(|arg: String| {
-			println!("{}", arg);
-		});
-		let _ = (c, c);
-	}
-	#[test]
-	fn fnmut() {
-		fn test<
-			F: FnMut(usize, &usize, &mut usize, String, &String, &mut String) -> String
-				+ Serialize
-				+ DeserializeOwned
-				+ PartialEq
-				+ Eq
-				+ Clone
-				+ fmt::Debug,
-		>(
-			mut f: F,
-		) {
-			let mut deserialized: F =
-				serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
-			let mut deserialized2: F =
-				bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
-			assert_eq!(f, deserialized);
-			assert_eq!(deserialized, deserialized2);
-			assert_eq!(f, deserialized2);
-			let test = |f: &mut F| {
-				let mut a = 3;
-				let mut b = String::from("ghi");
-				assert_eq!(
-					f(
-						1,
-						&2,
-						&mut a,
-						String::from("abc"),
-						&String::from("def"),
-						&mut b
-					),
-					"12qwertyghiqwertyabcdef129abcdefghiqwertyabcdef"
-				);
-				a += 6;
-				b += "pqr";
-				assert_eq!(f(4, &5, &mut a, String::from("jkl"), &String::from("mno"), &mut b), "48qwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmno4536jklmnoghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmno");
-				a += 9;
-				b += "yz";
-				assert_eq!(f(7, &8, &mut a, String::from("stu"), &String::from("vwx"), &mut b), "156qwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoyzqwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnostuvwx78108stuvwxghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoyzqwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnostuvwx");
-			};
-			test(&mut f);
-			test(&mut deserialized);
-			test(&mut deserialized2);
-			assert_eq!(f, deserialized);
-			assert_eq!(deserialized, deserialized2);
-			assert_eq!(f, deserialized2);
-		}
-		let (a, b) = (3_usize, String::from("qwerty"));
-		let a = FnMut!([a,b] move |c,d:&_,e:&mut _,f:String,g:&String,h:&mut String| -> String {
-			*e += *a+c+*d;
-			*a += *e;
-			*h += (b.clone()+f.as_str()+g.as_str()).as_str();
-			*b += h.as_str();
-			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
-		});
-		test(a);
-		fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
-		where
-			F: FnMut(&mut St) -> Option<A> + Serialize,
-		{
-			Unfold {
-				_f: f,
-				_state: initial_state,
-			}
-		}
-		struct Unfold<St, F> {
-			_f: F,
-			_state: St,
-		}
-		let _ = unfold(0_usize, FnMut!(|acc: &mut _| Some(*acc)));
-		let x = 123_usize;
-		let c = FnMut!([x] move|arg:String|{
-			println!("{} {}", x, arg);
-		});
-		let _ = (c, c);
-	}
-	#[test]
-	fn fnref() {
-		fn test<
-			F: Fn(
-					usize,
-					&usize,
-					&mut usize,
-					&usize,
-					&mut usize,
-					String,
-					&String,
-					&mut String,
-				) -> String
-				+ Serialize
-				+ DeserializeOwned
-				+ PartialEq
-				+ Eq
-				+ Clone
-				+ fmt::Debug,
-		>(
-			mut f: F,
-		) {
-			let mut deserialized: F =
-				serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
-			let mut deserialized2: F =
-				bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
-			assert_eq!(f, deserialized);
-			assert_eq!(deserialized, deserialized2);
-			assert_eq!(f, deserialized2);
-			let test = |f: &mut F| {
-				let mut a = 3;
-				let mut b = String::from("ghi");
-				let mut x = 11;
-				assert_eq!(
-					f(
-						1,
-						&2,
-						&mut a,
-						&10,
-						&mut x,
-						String::from("abc"),
-						&String::from("def"),
-						&mut b
-					),
-					"3qwerty129abcdefghiqwertyabcdef"
-				);
-				a += 6;
-				b += "pqr";
-				x += 13;
-				assert_eq!(
-					f(
-						4,
-						&5,
-						&mut a,
-						&12,
-						&mut x,
-						String::from("jkl"),
-						&String::from("mno"),
-						&mut b
-					),
-					"3qwerty4527jklmnoghiqwertyabcdefpqrqwertyjklmno"
-				);
-				a += 9;
-				b += "yz";
-				x += 15;
-				assert_eq!(
-					f(
-						7,
-						&8,
-						&mut a,
-						&14,
-						&mut x,
-						String::from("stu"),
-						&String::from("vwx"),
-						&mut b
-					),
-					"3qwerty7854stuvwxghiqwertyabcdefpqrqwertyjklmnoyzqwertystuvwx"
-				);
-			};
-			test(&mut f);
-			test(&mut deserialized);
-			test(&mut deserialized2);
-			assert_eq!(f, deserialized);
-			assert_eq!(deserialized, deserialized2);
-			assert_eq!(f, deserialized2);
-		}
-		let (a, b) = (3_usize, String::from("qwerty"));
-		{
-			assert_eq!(
-				Fn!([a,b] |c:usize,d:&usize,e:&mut usize,&_x:&usize,&mut _y:&mut usize,f:String,g:&String,h:&mut String| -> String {
-					*e += *a+c+*d;
-					// *a += *e;
-					*h += (b.clone()+f.as_str()+g.as_str()).as_str();
-					// *b += h.as_str();
-					format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
-				})(
-					0,
-					&1,
-					&mut 2,
-					&3,
-					&mut 4,
-					String::from("a"),
-					&String::from("b"),
-					&mut String::from("c")
-				),
-				"3qwerty016abcqwertyab"
-			);
-		}
-		let x = Fn!([a,b] move |c,d:&_,e:&mut _,&_x,&mut _y,f:String,g:&String,h:&mut String| -> String {
-			*e += *a+c+*d;
-			// *a += *e;
-			*h += (b.clone()+f.as_str()+g.as_str()).as_str();
-			// *b += h.as_str();
-			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
-		});
-		test(x);
-		fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
-		where
-			F: Fn(&mut St) -> Option<A> + Serialize,
-		{
-			Unfold {
-				_f: f,
-				_state: initial_state,
-			}
-		}
-		struct Unfold<St, F> {
-			_f: F,
-			_state: St,
-		}
-		let _ = unfold(0_usize, Fn!(|acc: &mut _| Some(*acc)));
-		let x = 123_usize;
-		let c = unsafe {
-			// to check unused_unsafe in macro
-			Fn!([x] move|arg:String|{
-				println!("{} {}", x, arg);
-			})
-		};
-		let _ = (c, c);
-	}
-	#[test]
-	fn multi_process() {
-		let exe = env::current_exe().unwrap();
-		if let Ok(x) = env::var("SPAWNED_TOKEN_SERDECLOSURE") {
-			let mut f: super::FnMut<
-				(usize, String),
-				for<'r, 's, 't0, 't1, 't2> fn(
-					&'r mut (usize, String),
-					(
-						usize,
-						&'s usize,
-						&'t0 mut usize,
-						String,
-						&'t1 String,
-						&'t2 mut String,
-					),
-				) -> String,
-			> = serde_json::from_str(&x).unwrap();
-			let mut a = 3;
-			let mut b = String::from("ghi");
-			assert_eq!(
-				f(
-					1,
-					&2,
-					&mut a,
-					String::from("abc"),
-					&String::from("def"),
-					&mut b
-				),
-				"12qwertyghiqwertyabcdef129abcdefghiqwertyabcdef"
-			);
-			println!("success_token_serdeclosure {:?}", f);
-			return;
-		}
-		let (a, b) = (3_usize, String::from("qwerty"));
-		let a: super::FnMut<
-			(usize, String),
-			for<'r, 's, 't0, 't1, 't2> fn(
-				&'r mut (usize, String),
-				(
-					usize,
-					&'s usize,
-					&'t0 mut usize,
-					String,
-					&'t1 String,
-					&'t2 mut String,
-				),
-			) -> String,
-		> = FnMut!([a,b] move |c,d:&_,e:&mut _,f:String,g:&String,h:&mut String| -> String {
-			*e += *a+c+*d;
-			*a += *e;
-			*h += (b.clone()+f.as_str()+g.as_str()).as_str();
-			*b += h.as_str();
-			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
-		});
-		for i in 0..100 {
-			let output = process::Command::new(&exe)
-				.arg("--nocapture")
-				.arg("--exact")
-				.arg("tests::multi_process")
-				.env(
-					"SPAWNED_TOKEN_SERDECLOSURE",
-					serde_json::to_string(&a).unwrap(),
-				)
-				.output()
-				.unwrap();
-			if !str::from_utf8(&output.stdout)
-				.unwrap()
-				.contains("success_token_serdeclosure")
-				|| !output.status.success()
-			{
-				panic!("{}: {:?}", i, output);
-			}
-		}
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		Debug::fmt(&self.f, f)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@
 //!     |     in this macro invocation
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.0")]
 #![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,373 @@
+use serde::{de::DeserializeOwned, Serialize};
+use std::{fmt::Debug, mem::size_of};
+
+#[macro_use]
+extern crate serde_closure;
+
+#[test]
+fn fn_ptr_size() {
+	assert_eq!(size_of::<usize>(), size_of::<fn()>());
+}
+
+#[test]
+fn fnonce() {
+	fn test<
+		F: FnOnce(usize, &usize, &mut usize, String, &String, &mut String) -> String
+			+ Serialize
+			+ DeserializeOwned
+			+ PartialEq
+			+ Eq
+			+ Clone
+			+ Debug,
+	>(
+		f: F,
+	) {
+		let deserialized: F = serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
+		let deserialized2: F = bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
+		assert_eq!(f, deserialized);
+		assert_eq!(deserialized, deserialized2);
+		assert_eq!(f, deserialized2);
+		let test = |f: F| {
+			let mut a = 3;
+			let mut b = String::from("ghi");
+			assert_eq!(
+				f.clone()(
+					1,
+					&2,
+					&mut a,
+					String::from("abc"),
+					&String::from("def"),
+					&mut b
+				),
+				"12qwertyghiqwertyabcdef129abcdefghiqwertyabcdef"
+			);
+			a += 6;
+			b += "pqr";
+			assert_eq!(
+				f.clone()(
+					4,
+					&5,
+					&mut a,
+					String::from("jkl"),
+					&String::from("mno"),
+					&mut b
+				),
+				"30qwertyghiqwertyabcdefpqrqwertyjklmno4527jklmnoghiqwertyabcdefpqrqwertyjklmno"
+			);
+			a += 9;
+			b += "yz";
+			assert_eq!(
+				f(
+					7,
+					&8,
+					&mut a,
+					String::from("stu"),
+					&String::from("vwx"),
+					&mut b
+				),
+				"57qwertyghiqwertyabcdefpqrqwertyjklmnoyzqwertystuvwx7854stuvwxghiqwertyabcdefpqrqwertyjklmnoyzqwertystuvwx"
+			);
+		};
+		test(f);
+		test(deserialized);
+		test(deserialized2);
+	}
+	let (a, b) = (3_usize, String::from("qwerty"));
+	let a = FnOnce!(
+		move |c, d: &_, e: &mut _, f: String, g: &String, h: &mut String| -> String {
+			a = a;
+			b = b;
+			*e += a + c + *d;
+			a += *e;
+			*h += (b.clone() + f.as_str() + g.as_str()).as_str();
+			b += h.as_str();
+			let (a, b) = (&a, &b);
+			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
+		}
+	);
+	test(a);
+	let b = FnOnce!(|a| {
+		println!("{:?}", a);
+	});
+	b(0_usize);
+	let c = FnOnce!(|arg: String| {
+		println!("{}", arg);
+	});
+	let _ = (c, c);
+}
+
+#[test]
+fn fnmut() {
+	fn test<
+		F: FnMut(usize, &usize, &mut usize, String, &String, &mut String) -> String
+			+ Serialize
+			+ DeserializeOwned
+			+ PartialEq
+			+ Eq
+			+ Clone
+			+ Debug,
+	>(
+		mut f: F,
+	) {
+		let mut deserialized: F =
+			serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
+		let mut deserialized2: F = bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
+		assert_eq!(f, deserialized);
+		assert_eq!(deserialized, deserialized2);
+		assert_eq!(f, deserialized2);
+		let test = |f: &mut F| {
+			let mut a = 3;
+			let mut b = String::from("ghi");
+			assert_eq!(
+				f(
+					1,
+					&2,
+					&mut a,
+					String::from("abc"),
+					&String::from("def"),
+					&mut b
+				),
+				"12qwertyghiqwertyabcdef129abcdefghiqwertyabcdef"
+			);
+			a += 6;
+			b += "pqr";
+			assert_eq!(f(4, &5, &mut a, String::from("jkl"), &String::from("mno"), &mut b), "48qwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmno4536jklmnoghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmno");
+			a += 9;
+			b += "yz";
+			assert_eq!(f(7, &8, &mut a, String::from("stu"), &String::from("vwx"), &mut b), "156qwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoyzqwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnostuvwx78108stuvwxghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnoyzqwertyghiqwertyabcdefghiqwertyabcdefpqrqwertyghiqwertyabcdefjklmnostuvwx");
+		};
+		test(&mut f);
+		test(&mut deserialized);
+		test(&mut deserialized2);
+		assert_eq!(f, deserialized);
+		assert_eq!(deserialized, deserialized2);
+		assert_eq!(f, deserialized2);
+	}
+	let (mut a, mut b) = (3_usize, String::from("qwerty"));
+	{
+		assert_eq!(
+			FnMut!(|c: usize,
+			        d: &usize,
+			        e: &mut usize,
+			        &_x: &usize,
+			        &mut _y: &mut usize,
+			        f: String,
+			        g: &String,
+			        h: &mut String|
+			 -> String {
+				*e += a + c + *d;
+				// *a += *e;
+				*h += (b.clone() + f.as_str() + g.as_str()).as_str();
+				// *b += h.as_str();
+				let (a, b) = (&a, &b);
+				format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
+			})(
+				0,
+				&1,
+				&mut 2,
+				&3,
+				&mut 4,
+				String::from("a"),
+				&String::from("b"),
+				&mut String::from("c")
+			),
+			"3qwerty016abcqwertyab"
+		);
+	}
+	let a = FnMut!(
+		move |c, d: &_, e: &mut _, f: String, g: &String, h: &mut String| -> String {
+			*e += a + c + *d;
+			a += *e;
+			*h += (b.clone() + f.as_str() + g.as_str()).as_str();
+			b += h.as_str();
+			let (a, b) = (&a, &b);
+			format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
+		}
+	);
+	test(a);
+	fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
+	where
+		F: FnMut(&mut St) -> Option<A> + Serialize,
+	{
+		Unfold {
+			_f: f,
+			_state: initial_state,
+		}
+	}
+	struct Unfold<St, F> {
+		_f: F,
+		_state: St,
+	}
+	let _ = unfold(0_usize, FnMut!(|acc: &mut _| Some(*acc)));
+	let x = 123_usize;
+	let c = FnMut!(move |arg: String| {
+		let x = &x;
+		println!("{} {}", x, arg);
+	});
+	let _ = (c, c);
+}
+
+#[test]
+fn fnref() {
+	fn test<
+		F: Fn(
+				usize,
+				&usize,
+				&mut usize,
+				&usize,
+				&mut usize,
+				String,
+				&String,
+				&mut String,
+			) -> String
+			+ Serialize
+			+ DeserializeOwned
+			+ PartialEq
+			+ Eq
+			+ Clone
+			+ Debug,
+	>(
+		mut f: F,
+	) {
+		let mut deserialized: F =
+			serde_json::from_str(&serde_json::to_string(&f).unwrap()).unwrap();
+		let mut deserialized2: F = bincode::deserialize(&bincode::serialize(&f).unwrap()).unwrap();
+		assert_eq!(f, deserialized);
+		assert_eq!(deserialized, deserialized2);
+		assert_eq!(f, deserialized2);
+		let test = |f: &mut F| {
+			let mut a = 3;
+			let mut b = String::from("ghi");
+			let mut x = 11;
+			assert_eq!(
+				f(
+					1,
+					&2,
+					&mut a,
+					&10,
+					&mut x,
+					String::from("abc"),
+					&String::from("def"),
+					&mut b
+				),
+				"3qwerty129abcdefghiqwertyabcdef"
+			);
+			a += 6;
+			b += "pqr";
+			x += 13;
+			assert_eq!(
+				f(
+					4,
+					&5,
+					&mut a,
+					&12,
+					&mut x,
+					String::from("jkl"),
+					&String::from("mno"),
+					&mut b
+				),
+				"3qwerty4527jklmnoghiqwertyabcdefpqrqwertyjklmno"
+			);
+			a += 9;
+			b += "yz";
+			x += 15;
+			assert_eq!(
+				f(
+					7,
+					&8,
+					&mut a,
+					&14,
+					&mut x,
+					String::from("stu"),
+					&String::from("vwx"),
+					&mut b
+				),
+				"3qwerty7854stuvwxghiqwertyabcdefpqrqwertyjklmnoyzqwertystuvwx"
+			);
+		};
+		test(&mut f);
+		test(&mut deserialized);
+		test(&mut deserialized2);
+		assert_eq!(f, deserialized);
+		assert_eq!(deserialized, deserialized2);
+		assert_eq!(f, deserialized2);
+	}
+	let (a, b) = (3_usize, String::from("qwerty"));
+	{
+		assert_eq!(
+			Fn!(|c: usize,
+			     d: &usize,
+			     e: &mut usize,
+			     &_x: &usize,
+			     &mut _y: &mut usize,
+			     f: String,
+			     g: &String,
+			     h: &mut String|
+			 -> String {
+				*e += a + c + *d;
+				// *a += *e;
+				*h += (b.clone() + f.as_str() + g.as_str()).as_str();
+				// *b += h.as_str();
+				let (a, b) = (&a, &b);
+				format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
+			})(
+				0,
+				&1,
+				&mut 2,
+				&3,
+				&mut 4,
+				String::from("a"),
+				&String::from("b"),
+				&mut String::from("c")
+			),
+			"3qwerty016abcqwertyab"
+		);
+	}
+	let x = Fn!(move |c,
+	                  d: &_,
+	                  e: &mut _,
+	                  &_x,
+	                  &mut _y: _,
+	                  f: String,
+	                  g: &String,
+	                  h: &mut String|
+	      -> String {
+		*e += a + c + *d;
+		// *a += *e;
+		*h += (b.clone() + f.as_str() + g.as_str()).as_str();
+		// *b += h.as_str();
+		let (a, b) = (&a, &b);
+		format!("{}{}{}{}{}{}{}{}", a, b, c, d, e, f, g, h)
+	});
+	test(x);
+	fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
+	where
+		F: Fn(&mut St) -> Option<A> + Serialize,
+	{
+		Unfold {
+			_f: f,
+			_state: initial_state,
+		}
+	}
+	struct Unfold<St, F> {
+		_f: F,
+		_state: St,
+	}
+	let _ = unfold(0_usize, Fn!(|acc: &mut _| Some(*acc)));
+	let x = 123_usize;
+	let c = Fn!(move |arg: String| {
+		let x = &x;
+		println!("{} {}", x, arg);
+	});
+	let _ = (c, c);
+}
+
+mod no_prelude {
+	#![no_implicit_prelude]
+
+	#[test]
+	fn no_prelude() {
+		let a = ::std::string::String::new();
+		::serde_closure::FnOnce!(|| a);
+	}
+}


### PR DESCRIPTION
Procedural macros are far more powerful than the `macro_rules!` macros-1.0 used previously.

Many limitations have been lifted, including:
 * fixes #7
 * no longer need to explicitly list captured variables
 * no longer need to deref captured variables
 * no longer need to occasionally duplicate the type of captured variables inside the closure

One downside is that the resultant closures are no longer nameable (normal closures are not nameable either). This can be resolved by upcasting to a trait object. https://github.com/alecmocatta/serde_traitobject can be then used to serialize that trait object.