### PR TITLE
Deconstruct the env struct for FnOnce closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros that wrap closures to make them serializable and de
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.2"
+documentation = "https://docs.rs/serde_closure/0.2.3"
 readme = "README.md"
 edition = "2018"
 
@@ -23,7 +23,7 @@ azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-serde_closure_derive = { version = "=0.2.2", path = "serde_closure_derive" }
+serde_closure_derive = { version = "=0.2.3", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
 proc-macro-hack = "0.5"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_closure/0.2.2)
+[Docs](https://docs.rs/serde_closure/0.2.3)
 
 Serializable and debuggable closures.
 
@@ -30,9 +30,9 @@ requires nightly Rust for the `unboxed_closures` and `fn_traits` features (rust
 issue [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.2.2/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.2.2/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.2.2/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2.3/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2.3/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2.3/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See https://crates.io/crates/serde_closure for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.2"
+documentation = "https://docs.rs/serde_closure/0.2.3"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -9,7 +9,7 @@
 //! See [`serde_closure`](https://docs.rs/serde_closure/) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.3")]
 #![feature(proc_macro_diagnostic)]
 #![allow(non_snake_case)] // due to proc-macro-hack can't apply this directly
 

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -691,13 +691,14 @@ impl<'a> State<'a> {
 					// structs/enum variants and functions. Use the case of the first char as a heuristic.
 					if !ident.to_string().chars().next().unwrap().is_uppercase() {
 						let _ = self.env_variables.insert(ident.clone());
-						let mut a = Expr::Path(ExprPath {
-							attrs: attrs.clone(),
-							qself: None,
-							path: path.clone(),
-						});
-						if self.env_struct {
-							a = Expr::Field(ExprField {
+						let mut a = if !self.env_struct {
+							Expr::Path(ExprPath {
+								attrs: attrs.clone(),
+								qself: None,
+								path: path.clone(),
+							})
+						} else {
+							Expr::Field(ExprField {
 								attrs: vec![],
 								base: Box::new(Expr::Path(ExprPath {
 									attrs: attrs.clone(),
@@ -713,8 +714,8 @@ impl<'a> State<'a> {
 								})),
 								dot_token: Default::default(),
 								member: Member::Named(ident.clone()),
-							});
-						}
+							})
+						};
 						if self.deref {
 							a = Expr::Unary(ExprUnary {
 								attrs: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@
 //! [`serde_traitobject`](https://github.com/alecmocatta/serde_traitobject)
 //! would help you to send serializable closures between them.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.3")]
 #![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -93,6 +93,17 @@ fn fnonce() {
 		println!("{}", arg);
 	});
 	let _ = (c, c);
+
+	let reduce = String::new();
+	let tasks = vec![' '];
+	let tasks2 = tasks.clone();
+	let c = FnOnce!(move || -> String {
+		for task in tasks {
+			(|| reduce.push(task))();
+		}
+		reduce
+	});
+	assert_eq!(c(), tasks2.into_iter().collect::<String>());
 }
 
 #[test]


### PR DESCRIPTION
The type system is more flexible to variables than to members of a struct. This PR switches captured variables in `FnOnce!` closures to variables, which resolves a minor incompatibility with normal `FnOnce` closures.