### PR TITLE
Statically assert idents inferred to be variables aren't nameable types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+tab_width = 4
+
+[.*]
+tab_width = 4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.2.5"
+version = "0.2.6"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros that wrap closures to make them serializable and de
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.5"
+documentation = "https://docs.rs/serde_closure/0.2.6"
 readme = "README.md"
 edition = "2018"
 
@@ -23,7 +23,7 @@ azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-serde_closure_derive = { version = "=0.2.5", path = "serde_closure_derive" }
+serde_closure_derive = { version = "=0.2.6", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
 proc-macro-hack = "0.5"
 

--- a/README.md
+++ b/README.md
@@ -86,43 +86,44 @@ FnMut!(move |name| {
 
 ## Limitations
 There are currently some minor limitations:
- * Captured variables with an uppercase first letter need to be explicitly
-   captured. If you see a panic like the following, fix the case of the
-   variable.
+
+ * Use of types that start with a lowercase letter need might need to be
+   disambiguated from variables. If you see an error like the following, fix the
+   case of the type, or append it with `my_struct::<>` to disambiguate.
 ```text
-thread 'main' panicked at 'A variable with an upper case first letter was implicitly captured.
-Unfortunately due to current limitations it must be captured explicitly.
-Please refer to the README.', tests/test.rs:205:10
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
-```
- * Functions called inside the closure might need to be disambiguated. This
-   also affects enum unit and tuple variants with a lowercase first letter.
-   If you see an error like either of the following, qualify `my_function`
-   as `self::my_function` and `my_enum_variant` as
-   `MyEnum::my_enum_variant`.
-```text
-error[E0277]: the trait bound `fn(usize) -> std::option::Option<usize> {my_function::<usize>}: fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not satisfied
-   --> tests/test.rs:327:10
+error[E0308]: mismatched types
+   --> tests/test.rs:450:4
     |
-314 |     fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
-    |        ------
-315 |     where
-316 |         F: Fn(&mut St) -> Option<A> + Serialize,
-    |                                       --------- required by this bound in `fnref::unfold`
-...
-327 |     let _ = unfold(0_usize, Fn!(|acc: &mut _| my_function(*acc)));
-    |             ^^^^^^ the trait `fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not implemented for `fn(usize) -> std::option::Option<usize> {my_function::<usize>}`
-```
-```text
-error[E0530]: function parameters cannot shadow tuple variants
-   --> tests/test.rs:173:47
+449 |       FnOnce!(move || {
+    |  _____-
+450 | |         my_struct;
+    | |         ^^^^^^^^^ expected struct `serde_closure::internal::a_variable`, found struct `my_struct`
+451 | |     });
+    | |______- in this macro invocation
     |
-173 |     FnMut!(|acc: &mut _| my_enum_variant(*acc))
-    |     ---------------------^^^^^^^^^^^^^^^-------
-    |     |                    |
-    |     |                    cannot be named the same as a tuple variant
-    |     in this macro invocation
+    = note: expected type `serde_closure::internal::a_variable`
+               found type `my_struct`
 ```
+
+ * Use of variables that start with an uppercase letter might need to be
+   disambiguated from types. If you see an error like the following, fix the
+   case of the variable, or wrap it with `(MyVariable)` to disambiguate.
+```text
+error: imports cannot refer to local variables
+   --> tests/test.rs:422:3
+    |
+417 |       FnOnce!(move || {
+    |  _____-
+418 | |         MyVariable;
+    | |         ^^^^^^^^^^
+419 | |     });
+    | |______- in this macro invocation
+    |
+```
+
+ * Functions and closures called inside the closure might need to be
+   disambiguated. This can be done the same as above with `function::<>` for
+   functions and `(closure)` for closures.
 
 ## Serializing between processes
 
@@ -140,7 +141,10 @@ processes running the same binary.
 For example, if you have multiple forks of a process, or the same binary running
 on each of a cluster of machines,
 [`serde_traitobject`](https://github.com/alecmocatta/serde_traitobject) would
-help you to send serializable closures between them.
+help you to send serializable closures between them. This can be done by
+upcasting the closure to a `Box<dyn serde_traitobject::Fn()>`, which is
+automatically serializable and deserializable with
+[`serde`](https://github.com/serde-rs/serde).
 
 ## License
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_closure/0.2.5)
+[Docs](https://docs.rs/serde_closure/0.2.6)
 
 Serializable and debuggable closures.
 
@@ -30,9 +30,9 @@ requires nightly Rust for the `unboxed_closures` and `fn_traits` features (rust
 issue [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.2.5/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.2.5/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.2.5/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2.6/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2.6/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2.6/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.2.5"
+version = "0.2.6"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See https://crates.io/crates/serde_closure for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.5"
+documentation = "https://docs.rs/serde_closure/0.2.6"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -9,7 +9,7 @@
 //! See [`serde_closure`](https://docs.rs/serde_closure/) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.5")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.6")]
 #![feature(proc_macro_diagnostic)]
 #![allow(non_snake_case)] // due to proc-macro-hack can't apply this directly
 

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -404,6 +404,10 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 				#fn_impl
 			}
 
+			{
+				#(let #env_variables = ::serde_closure::internal::a_variable;)*
+			}
+
 			let mut #ret_name = #impls_name::#name::new(#env_capture);
 			let #env_types_name = ::serde_closure::internal::to_phantom(&#ret_name);
 
@@ -716,11 +720,10 @@ impl<'a> State<'a> {
 							expr: Box::new(a),
 						});
 					} else {
-						let mut path_segment: PathSegment = (*path_segment).clone();
-						path_segment.arguments = PathArguments::None;
+						let ident = (*ident).clone();
 						*expr = parse2(quote_spanned! { expr.span() =>
 							({
-								use #path_segment;
+								use #ident;
 								fn eq<T>(a: T, b: T) -> T { a }
 								eq(#expr, #expr)
 							})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@
 //! automatically serializable and deserializable with
 //! [`serde`](https://github.com/serde-rs/serde).
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.5")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.6")]
 #![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub mod internal {
 pub mod structs {
 	//! Structs representing a serializable closure, created by the
 	//! [`FnOnce`](macro@FnOnce), [`FnMut`](macro@FnMut) and [`Fn`](macro@Fn)
-	//! macros. They Implement [`std::ops::FnOnce`], [`std::ops::FnMut`] and
+	//! macros. They implement [`std::ops::FnOnce`], [`std::ops::FnMut`] and
 	//! [`std::ops::Fn`] respectively, as well as [`Debug`](std::fmt::Debug),
 	//! [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize),
 	//! and various convenience traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,43 +104,44 @@
 //!
 //! # Limitations
 //! There are currently some minor limitations:
-//!  * Captured variables with an uppercase first letter need to be explicitly
-//!    captured. If you see a panic like the following, fix the case of the
-//!    variable.
+//!
+//!  * Use of types that start with a lowercase letter need might need to be
+//!    disambiguated from variables. If you see an error like the following, fix
+//!    the case of the type, or append it with `my_struct::<>` to disambiguate.
 //! ```text
-//! thread 'main' panicked at 'A variable with an upper case first letter was implicitly captured.
-//! Unfortunately due to current limitations it must be captured explicitly.
-//! Please refer to the README.', tests/test.rs:205:10
-//! note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
-//! ```
-//!  * Functions called inside the closure might need to be disambiguated. This
-//!    also affects enum unit and tuple variants with a lowercase first letter.
-//!    If you see an error like either of the following, qualify `my_function`
-//!    as `self::my_function` and `my_enum_variant` as
-//!    `MyEnum::my_enum_variant`.
-//! ```text
-//! error[E0277]: the trait bound `fn(usize) -> std::option::Option<usize> {my_function::<usize>}: fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not satisfied
-//!    --> tests/test.rs:327:10
+//! error[E0308]: mismatched types
+//!    --> tests/test.rs:450:4
 //!     |
-//! 314 |     fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
-//!     |        ------
-//! 315 |     where
-//! 316 |         F: Fn(&mut St) -> Option<A> + Serialize,
-//!     |                                       --------- required by this bound in `fnref::unfold`
-//! ...
-//! 327 |     let _ = unfold(0_usize, Fn!(|acc: &mut _| my_function(*acc)));
-//!     |             ^^^^^^ the trait `fnref::_IMPL_DESERIALIZE_FOR_Fn::_serde::Serialize` is not implemented for `fn(usize) -> std::option::Option<usize> {my_function::<usize>}`
-//! ```
-//! ```text
-//! error[E0530]: function parameters cannot shadow tuple variants
-//!    --> tests/test.rs:173:47
+//! 449 |       FnOnce!(move || {
+//!     |  _____-
+//! 450 | |         my_struct;
+//!     | |         ^^^^^^^^^ expected struct `serde_closure::internal::a_variable`, found struct `my_struct`
+//! 451 | |     });
+//!     | |______- in this macro invocation
 //!     |
-//! 173 |     FnMut!(|acc: &mut _| my_enum_variant(*acc))
-//!     |     ---------------------^^^^^^^^^^^^^^^-------
-//!     |     |                    |
-//!     |     |                    cannot be named the same as a tuple variant
-//!     |     in this macro invocation
+//!     = note: expected type `serde_closure::internal::a_variable`
+//!                found type `my_struct`
 //! ```
+//!
+//!  * Use of variables that start with an uppercase letter might need to be
+//!    disambiguated from types. If you see an error like the following, fix the
+//!    case of the variable, or wrap it with `(MyVariable)` to disambiguate.
+//! ```text
+//! error: imports cannot refer to local variables
+//!    --> tests/test.rs:422:3
+//!     |
+//! 417 |       FnOnce!(move || {
+//!     |  _____-
+//! 418 | |         MyVariable;
+//!     | |         ^^^^^^^^^^
+//! 419 | |     });
+//!     | |______- in this macro invocation
+//!     |
+//! ```
+//!
+//!  * Functions and closures called inside the closure might need to be
+//!    disambiguated. This can be done the same as above with `function::<>` for
+//!    functions and `(closure)` for closures.
 //!
 //! # Serializing between processes
 //!
@@ -158,7 +159,10 @@
 //! For example, if you have multiple forks of a process, or the same binary
 //! running on each of a cluster of machines,
 //! [`serde_traitobject`](https://github.com/alecmocatta/serde_traitobject)
-//! would help you to send serializable closures between them.
+//! would help you to send serializable closures between them. This can be done
+//! by upcasting the closure to a `Box<dyn serde_traitobject::Fn()>`, which is
+//! automatically serializable and deserializable with
+//! [`serde`](https://github.com/serde-rs/serde).
 
 #![doc(html_root_url = "https://docs.rs/serde_closure/0.2.5")]
 #![feature(unboxed_closures, fn_traits)]
@@ -233,6 +237,13 @@ pub mod internal {
 
 	#[allow(missing_copy_implementations, missing_debug_implementations)]
 	pub struct ZeroSizedAssertion;
+
+	#[allow(
+		missing_copy_implementations,
+		missing_debug_implementations,
+		non_camel_case_types
+	)]
+	pub struct a_variable;
 }
 
 pub mod structs {


### PR DESCRIPTION
Unnameable types i.e. functions can still slip through.

Update docs with current static assertions