### PR TITLE
Mute warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.2.9"
+version = "0.2.10"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros that wrap closures to make them serializable and de
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.9"
+documentation = "https://docs.rs/serde_closure/0.2.10"
 readme = "README.md"
 edition = "2018"
 
@@ -23,7 +23,7 @@ azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-serde_closure_derive = { version = "=0.2.9", path = "serde_closure_derive" }
+serde_closure_derive = { version = "=0.2.10", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
 proc-macro-hack = "0.5"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_closure/0.2.9)
+[Docs](https://docs.rs/serde_closure/0.2.10)
 
 Serializable and debuggable closures.
 
@@ -30,9 +30,9 @@ requires nightly Rust for the `unboxed_closures` and `fn_traits` features (rust
 issue [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.2.9/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.2.9/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.2.9/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2.10/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2.10/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2.10/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
       mac:
         imageName: 'macos-10.13'
-        rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
+        rust_target_run: 'x86_64-apple-darwin'
       linux:
         imageName: 'ubuntu-16.04'
         rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl'

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.2.9"
+version = "0.2.10"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See https://crates.io/crates/serde_closure for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.9"
+documentation = "https://docs.rs/serde_closure/0.2.10"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -9,7 +9,7 @@
 //! See [`serde_closure`](https://docs.rs/serde_closure/) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.9")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.10")]
 #![feature(proc_macro_diagnostic)]
 #![allow(non_snake_case)] // due to proc-macro-hack can't apply this directly
 

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -261,6 +261,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 	Ok(quote! {
 		{
 			mod #impls_name {
+				#![allow(warnings)]
 				use ::serde_closure::{
 					internal::{self, is_phantom, to_phantom},
 					structs,
@@ -420,12 +421,16 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 			}
 
 			// This asserts that inferred env variables aren't nameable types.
+			#[allow(warnings)]
 			{
 				#(let #env_variables = ::serde_closure::internal::a_variable;)*
 			}
 			// This asserts that inferred env variables aren't types with >=1 type parameters.
-			if false {
-				#(&#env_variables::<>;)*
+			#[allow(warnings)]
+			{
+				if false {
+					#(&#env_variables::<>;)*
+				}
 			}
 			// TODO: Work out how to assert env variables aren't unnameable types with 0 type parameters.
 			// This might work in the future, but today it causes borrowck issues:
@@ -442,19 +447,24 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 
 			let closure =
 				#(#attrs)* #asyncness move |mut #env_name: #env_type, (#(#input_pats,)*): (#(#input_types,)*)| #output {
-					if false {
-						::serde_closure::internal::is_phantom(& #env_deref, #env_types_name);
+					#[allow(warnings)]
+					{
+						if false {
+							::serde_closure::internal::is_phantom(& #env_deref, #env_types_name);
+						}
 					}
 					#env_deconstruct
 					#body
 				};
 
-			if false {
-				#[allow(unreachable_code)]
-				let _ = closure(#ret_ref, loop {});
-			}
-			if false {
-				let ::serde_closure::internal::ZeroSizedAssertion = unsafe { ::serde_closure::internal::core::mem::transmute(closure) };
+			#[allow(warnings)]
+			{
+				if false {
+					let _ = closure(#ret_ref, loop {});
+				}
+				if false {
+					let ::serde_closure::internal::ZeroSizedAssertion = unsafe { ::serde_closure::internal::core::mem::transmute(closure) };
+				}
 			}
 
 			::serde_closure::structs::#name::internal_new(#ret_name.with_f(closure))
@@ -580,7 +590,10 @@ impl<'a> State<'a> {
 				let not_env_variables = take(self.not_env_variables).into_iter();
 				let mut vec = Vec::with_capacity(2);
 				if not_env_variables.len() != 0 {
-					vec.push(parse2(quote! { { #(use #not_env_variables;)* } }).unwrap());
+					vec.push(
+						parse2(quote! { #[allow(warnings)] { #(use #not_env_variables;)* } })
+							.unwrap(),
+					);
 				}
 				vec.push(stmt);
 				vec

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@
 //! automatically serializable and deserializable with
 //! [`serde`](https://github.com/serde-rs/serde).
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.9")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.10")]
 #![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,


### PR DESCRIPTION
New lint `clippy::single_component_path_imports` was being triggered. Use `#[allow(warnings)]` on generated code to mute them.

Release v0.2.10