### PR TITLE
Fix captured variable clashing with marker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.2.12"
+version = "0.2.13"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros that wrap closures to make them serializable and de
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.12"
+documentation = "https://docs.rs/serde_closure/0.2.13"
 readme = "README.md"
 edition = "2018"
 
@@ -23,7 +23,7 @@ azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests", buil
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-serde_closure_derive = { version = "=0.2.12", path = "serde_closure_derive" }
+serde_closure_derive = { version = "=0.2.13", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build?definitionId=10)
 
-[📖 Docs](https://docs.rs/serde_closure/0.2.12) | [💬 Chat](https://constellation.zulipchat.com/#narrow/stream/213236-subprojects)
+[📖 Docs](https://docs.rs/serde_closure/0.2.13/serde_closure/) | [💬 Chat](https://constellation.zulipchat.com/#narrow/stream/213236-subprojects)
 
 Serializable and debuggable closures.
 
@@ -30,9 +30,9 @@ requires nightly Rust for the `unboxed_closures` and `fn_traits` features (rust
 issue [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.2.12/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.2.12/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.2.12/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2020-06-09
+      rust_lint_toolchain: nightly-2020-06-10
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''
@@ -23,7 +23,7 @@ jobs:
     matrix:
       windows:
         imageName: 'windows-latest'
-        rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
+        rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc x86_64-pc-windows-gnu'
       mac:
         imageName: 'macos-latest'
         rust_target_run: 'x86_64-apple-darwin'

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.2.12"
+version = "0.2.13"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See https://crates.io/crates/serde_closure for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.12"
+documentation = "https://docs.rs/serde_closure/0.2.13"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -10,7 +10,7 @@
 //! See [`serde_closure`](https://docs.rs/serde_closure/) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.12")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.13")]
 #![feature(proc_macro_diagnostic)]
 
 use proc_macro2::{Span, TokenStream};

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -94,6 +94,8 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 	// Convert closure to use block so any not_env_variables can be asserted.
 	closure.body = Box::new(match *closure.body {
 		Expr::Block(block) => Expr::Block(block),
+		// Avoid clippy::unused_unit
+		Expr::Tuple(tuple) if tuple.elems.is_empty() => Expr::Tuple(tuple),
 		expr => Expr::Block(ExprBlock {
 			attrs: vec![],
 			label: None,
@@ -133,6 +135,11 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 	let capture = closure.capture;
 	let output = closure.output;
 	let body = closure.body;
+	// Avoid clippy::unused_unit
+	let body = match *body {
+		Expr::Tuple(tuple) if tuple.elems.is_empty() => None,
+		expr => Some(expr),
+	};
 	let input_pats = closure.inputs.iter().map(|input| match input {
 		Pat::Type(pat_type) => (*pat_type.pat).clone(),
 		pat => (*pat).clone(),

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -296,13 +296,13 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 				pub struct #name<#(#type_params,)* F> {
 					#( pub #env_variables: #type_params, )*
 					#[serde(skip)]
-					f: PhantomData<F>
+					__serde_closure_marker: PhantomData<F>
 				}
 				impl<#(#type_params,)*> #name<#(#type_params,)* ()> {
 					pub fn new(#( #env_variables: #type_params, )*) -> Self {
 						Self {
 							#( #env_variables ,)*
-							f: PhantomData
+							__serde_closure_marker: PhantomData
 						}
 					}
 					pub fn with_f<F1>(self, f: F1) -> #name<#(#type_params,)* F1> where F1: Copy {
@@ -311,7 +311,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 						}
 						#name {
 							#( #env_variables: self.#env_variables, )*
-							f: PhantomData
+							__serde_closure_marker: PhantomData
 						}
 					}
 				}
@@ -325,7 +325,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 					fn strip_f(self) -> #name<#(#type_params,)* ()> {
 						#name {
 							#( #env_variables: self.#env_variables, )*
-							f: PhantomData
+							__serde_closure_marker: PhantomData
 						}
 					}
 					fn strip_f_ref(&self) -> &#name<#(#type_params,)* ()> {
@@ -345,7 +345,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 					fn clone(&self) -> Self {
 						Self {
 							#( #env_variables: self.#env_variables.clone(), )*
-							f: PhantomData,
+							__serde_closure_marker: PhantomData,
 						}
 					}
 				}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! automatically serializable and deserializable with
 //! [`serde`](https://github.com/serde-rs/serde).
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.12")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.13")]
 #![feature(unboxed_closures, fn_traits)]
 #![warn(
 	missing_copy_implementations,


### PR DESCRIPTION
Also avoid triggering `clippy::unused_unit`.

Also release v0.2.13