### PR TITLE
Building on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_closure"
-version = "0.2.13"
+version = "0.2.14"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ This library provides macros that wrap closures to make them serializable and de
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.13"
+documentation = "https://docs.rs/serde_closure"
 readme = "README.md"
 edition = "2018"
 
@@ -27,7 +27,7 @@ default = ["nightly"]
 nightly = []
 
 [dependencies]
-serde_closure_derive = { version = "=0.2.13", path = "serde_closure_derive" }
+serde_closure_derive = { version = "=0.2.14", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ edition = "2018"
 azure-devops = { project = "alecmocatta/serde_closure", pipeline = "tests", build = "10" }
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["nightly"]
+nightly = []
+
 [dependencies]
 serde_closure_derive = { version = "=0.2.13", path = "serde_closure_derive" }
 serde = { version = "1.0", features = ["derive"] }
@@ -29,3 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 [dev-dependencies]
 serde_json = "1.0"
 bincode = "1.0"
+
+[[test]]
+name = "test"
+required-features = ["nightly"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_closure.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_closure/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_closure/_build?definitionId=10)
 
-[📖 Docs](https://docs.rs/serde_closure/0.2.13/serde_closure/) | [💬 Chat](https://constellation.zulipchat.com/#narrow/stream/213236-subprojects)
+[📖 Docs](https://docs.rs/serde_closure) | [💬 Chat](https://constellation.zulipchat.com/#narrow/stream/213236-subprojects)
 
 Serializable and debuggable closures.
 
@@ -30,9 +30,9 @@ requires nightly Rust for the `unboxed_closures` and `fn_traits` features (rust
 issue [#29625](https://github.com/rust-lang/rust/issues/29625)).
 
  * There are three macros,
-   [`FnOnce`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.FnOnce.html),
-   [`FnMut`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.FnMut.html)
-   and [`Fn`](https://docs.rs/serde_closure/0.2.13/serde_closure/macro.Fn.html),
+   [`FnOnce`](https://docs.rs/serde_closure/0.2/serde_closure/macro.FnOnce.html),
+   [`FnMut`](https://docs.rs/serde_closure/0.2/serde_closure/macro.FnMut.html)
+   and [`Fn`](https://docs.rs/serde_closure/0.2/serde_closure/macro.Fn.html),
    corresponding to the three types of Rust closure.
  * Wrap your closure with one of the macros and it will now implement `Copy`,
    `Clone`, `PartialEq`, `Eq`, `Hash`, `PartialOrd`, `Ord`, `Serialize`,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,10 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2020-06-10
+      rust_lint_toolchain: nightly-2020-07-09
       rust_flags: ''
-      rust_features: ''
+      rust_features_clippy: ';nightly'
+      rust_features: 'nightly'
       rust_target_check: ''
       rust_target_build: ''
       rust_target_run: ''

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_closure_derive"
-version = "0.2.13"
+version = "0.2.14"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -14,7 +14,7 @@ See https://crates.io/crates/serde_closure for documentation.
 """
 repository = "https://github.com/alecmocatta/serde_closure"
 homepage = "https://github.com/alecmocatta/serde_closure"
-documentation = "https://docs.rs/serde_closure/0.2.13"
+documentation = "https://docs.rs/serde_closure"
 edition = "2018"
 
 [badges]

--- a/serde_closure_derive/Cargo.toml
+++ b/serde_closure_derive/Cargo.toml
@@ -27,4 +27,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { version = "1.0.1", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0.2", default-features = false }
-syn = { version = "1.0.5", default-features = false, features = ["clone-impls", "full", "parsing", "printing", "proc-macro"] }
+syn = { version = "1.0.5", default-features = false, features = ["clone-impls", "full", "parsing", "printing", "proc-macro", "visit-mut"] }

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -7,10 +7,10 @@
 //! This library provides macros that wrap closures to make them serializable
 //! and debuggable.
 //!
-//! See [`serde_closure`](https://docs.rs/serde_closure/) for
+//! See [`serde_closure`](https://docs.rs/serde_closure) for
 //! documentation.
 
-#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.13")]
+#![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.14")]
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};

--- a/serde_closure_derive/src/lib.rs
+++ b/serde_closure_derive/src/lib.rs
@@ -11,13 +11,12 @@
 //! documentation.
 
 #![doc(html_root_url = "https://docs.rs/serde_closure_derive/0.2.13")]
-#![feature(proc_macro_diagnostic)]
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::{collections::HashSet, iter, iter::successors, mem::take, str};
 use syn::{
-	parse::{Parse, ParseStream}, parse2, spanned::Spanned, token::Bracket, Arm, Block, Error, Expr, ExprArray, ExprAssign, ExprAssignOp, ExprAsync, ExprAwait, ExprBinary, ExprBlock, ExprBox, ExprBreak, ExprCall, ExprCast, ExprClosure, ExprField, ExprForLoop, ExprGroup, ExprIf, ExprIndex, ExprLet, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall, ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprType, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue, Ident, Local, Member, Pat, PatBox, PatIdent, PatReference, PatSlice, PatTuple, PatTupleStruct, PatType, Path, PathArguments, PathSegment, Stmt, Type, TypeInfer, TypeReference, UnOp
+	parse::{Parse, ParseStream}, parse2, parse_macro_input, token::Bracket, visit_mut::{self, VisitMut}, Arm, AttributeArgs, Block, Error, Expr, ExprArray, ExprAssign, ExprAssignOp, ExprAsync, ExprAwait, ExprBinary, ExprBlock, ExprBox, ExprBreak, ExprCall, ExprCast, ExprClosure, ExprField, ExprForLoop, ExprGroup, ExprIf, ExprIndex, ExprLet, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall, ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprType, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue, Ident, Item, Lifetime, LifetimeDef, Local, Member, Pat, PatBox, PatIdent, PatReference, PatSlice, PatTuple, PatTupleStruct, PatType, Path, PathArguments, PathSegment, ReturnType, Stmt, TraitBound, Type, TypeInfer, TypeReference, TypeTuple, UnOp
 };
 
 #[proc_macro]
@@ -43,6 +42,79 @@ pub fn FnOnce(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 		.and_then(|closure| impl_fn_once(closure, Kind::FnOnce))
 		.unwrap_or_else(|err| err.to_compile_error())
 		.into()
+}
+
+#[proc_macro_attribute]
+pub fn generalize(
+	attr: proc_macro::TokenStream, item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let args: AttributeArgs = parse_macro_input!(attr);
+	assert_eq!(args.len(), 0);
+	let mut item = match syn::parse::<Item>(item) {
+		Err(err) => return err.to_compile_error().into(),
+		Ok(item) => item,
+	};
+	Generalizer.visit_item_mut(&mut item);
+	item.into_token_stream().into()
+}
+
+struct Generalizer;
+
+impl VisitMut for Generalizer {
+	fn visit_trait_bound_mut(&mut self, i: &mut TraitBound) {
+		if let PathSegment {
+			ident,
+			arguments: PathArguments::Parenthesized(args),
+		} = i.path.segments.last().unwrap()
+		{
+			if ident == "FnOnce" || ident == "FnMut" || ident == "Fn" {
+				let mut lifetimes = 0;
+				let mut inputs = args.inputs.clone();
+				for input in &mut inputs {
+					match input {
+						Type::Reference(TypeReference { lifetime, .. }) if lifetime.is_none() => {
+							*lifetime = Some(Lifetime::new(
+								&format!(
+									"'__serde_closure_{}",
+									bijective_base(lifetimes, 26, alpha_lower)
+								),
+								Span::call_site(),
+							));
+							lifetimes += 1;
+						}
+						_ => (),
+					}
+				}
+				if !inputs.empty_or_trailing() {
+					inputs.push_punct(Default::default());
+				}
+				let output = match &args.output {
+					ReturnType::Type(_, type_) => (&**type_).clone(),
+					ReturnType::Default => Type::Tuple(TypeTuple {
+						paren_token: Default::default(),
+						elems: Default::default(),
+					}),
+				};
+				let empty = syn::parse2(quote! {for <>}).unwrap();
+				i.lifetimes = Some(i.lifetimes.clone().unwrap_or(empty));
+				i.lifetimes
+					.as_mut()
+					.unwrap()
+					.lifetimes
+					.extend((0..lifetimes).map(|i| {
+						LifetimeDef::new(Lifetime::new(
+							&format!("'__serde_closure_{}", bijective_base(i, 26, alpha_lower)),
+							Span::call_site(),
+						))
+					}));
+				i.path = syn::parse2(
+					quote! { ::serde_closure::traits::#ident<(#inputs), Output = #output> },
+				)
+				.unwrap();
+			}
+		}
+		visit_mut::visit_trait_bound_mut(self, i)
+	}
 }
 
 struct Closure {
@@ -145,12 +217,14 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 		pat => (*pat).clone(),
 	});
 	let input_types = closure.inputs.iter().map(pat_to_type);
-	// let line_number = format!(" {}:{}:{}", closure.span().source_file(), closure.span().start().line, closure.span().start().column);
 
 	let type_params = &(0..env_variables.len())
 		.map(|i| {
 			Ident::new(
-				&format!("__SERDE_CLOSURE_{}", bijective_base(i as u64, 26, alpha)),
+				&format!(
+					"__SERDE_CLOSURE_{}",
+					bijective_base(i as u64, 26, alpha_upper)
+				),
 				span,
 			)
 		})
@@ -268,7 +342,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 	Ok(quote! {
 		{
 			mod #impls_name {
-				#![allow(warnings, unsafe_code)]
+				#![allow(warnings)]
 				use ::serde_closure::{
 					internal::{self, is_phantom, to_phantom},
 					structs,
@@ -317,11 +391,16 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 				}
 				impl<#(#type_params,)* F> #name<#(#type_params,)* F> {
 					fn f(&self) -> F {
-						// This is safe as an F has already been materialized (so we
-						// know it isn't uninhabited), it's Copy, it's not Drop, and
-						// its size is zero.
+						// This is safe as an F has already been materialized (so we know it isn't
+						// uninhabited), it's Copy, it's not Drop, its size is zero. Most
+						// importantly, thanks to the `use Type` static assertion, we're guaranteed
+						// not to be capturing anything other than `env_types_name`. Related:
+						// https://internals.rust-lang.org/t/is-synthesizing-zero-sized-values-safe/11506
 						unsafe { MaybeUninit::uninit().assume_init() }
 					}
+					// Strip F due to https://play.rust-lang.org/?edition=2018&gist=a2936c8b5abb13357d97bf835203b153
+					// Another struct could hold env vars and avoid these unsafes but that slightly
+					// increases complexity?
 					fn strip_f(self) -> #name<#(#type_params,)* ()> {
 						#name {
 							#( #env_variables: self.#env_variables, )*
@@ -461,7 +540,7 @@ fn impl_fn_once(closure: Closure, kind: Kind) -> Result<TokenStream, Error> {
 					#body
 				};
 
-			#[allow(warnings, unsafe_code)]
+			#[allow(warnings)]
 			{
 				if false {
 					let _ = closure(#ret_ref, loop {});
@@ -742,14 +821,8 @@ impl<'a> State<'a> {
 						|| is_func || has_path_arguments)
 					{
 						let _ = self.env_variables.insert(ident.clone());
-						let mut a = if !self.env_struct {
-							Expr::Path(ExprPath {
-								attrs: attrs.clone(),
-								qself: None,
-								path: path.clone(),
-							})
-						} else {
-							Expr::Field(ExprField {
+						if self.env_struct {
+							let mut a = Expr::Field(ExprField {
 								attrs: vec![],
 								base: Box::new(Expr::Path(ExprPath {
 									attrs: attrs.clone(),
@@ -765,20 +838,20 @@ impl<'a> State<'a> {
 								})),
 								dot_token: Default::default(),
 								member: Member::Named(ident.clone()),
-							})
-						};
-						if self.deref {
-							a = Expr::Unary(ExprUnary {
+							});
+							if self.deref {
+								a = Expr::Unary(ExprUnary {
+									attrs: vec![],
+									op: UnOp::Deref(Default::default()),
+									expr: Box::new(a),
+								});
+							}
+							*expr = Expr::Paren(ExprParen {
 								attrs: vec![],
-								op: UnOp::Deref(Default::default()),
+								paren_token: Default::default(),
 								expr: Box::new(a),
 							});
 						}
-						*expr = Expr::Paren(ExprParen {
-							attrs: vec![],
-							paren_token: Default::default(),
-							expr: Box::new(a),
-						});
 					} else {
 						let _ = self.not_env_variables.insert(ident.clone());
 					}
@@ -817,10 +890,12 @@ impl<'a> State<'a> {
 					};
 					mac.tokens = expr.args.to_token_stream();
 				} else {
-					mac.span()
-						.unwrap()
-						.warning("See https://github.com/alecmocatta/serde_closure/issues/16")
-						.emit()
+					panic!("See https://github.com/alecmocatta/serde_closure/issues/16");
+					// proc_macro_diagnostic: https://github.com/rust-lang/rust/issues/54140
+					// mac.span()
+					// 	.unwrap()
+					// 	.warning("See https://github.com/alecmocatta/serde_closure/issues/16")
+					// 	.emit()
 				}
 			}
 			_ => (),
@@ -829,9 +904,14 @@ impl<'a> State<'a> {
 }
 
 #[inline(always)]
-fn alpha(u: u8) -> u8 {
+fn alpha_upper(u: u8) -> u8 {
 	assert!(u < 26);
 	u + b'A'
+}
+#[inline(always)]
+fn alpha_lower(u: u8) -> u8 {
+	assert!(u < 26);
+	u + b'a'
 }
 const BUF_SIZE: usize = 64; // u64::max_value() in base 2
 fn bijective_base(n: u64, base: u64, digits: impl Fn(u8) -> u8) -> String {
@@ -855,18 +935,18 @@ fn bijective_base(n: u64, base: u64, digits: impl Fn(u8) -> u8) -> String {
 #[test]
 fn bijective_base_test() {
 	for i in 0..=26 + 26 * 26 + 26 * 26 * 26 {
-		let _ = bijective_base(i, 26, alpha);
+		let _ = bijective_base(i, 26, alpha_upper);
 	}
 	assert_eq!(
-		bijective_base(26 + 26 * 26 + 26 * 26 * 26, 26, alpha),
+		bijective_base(26 + 26 * 26 + 26 * 26 * 26, 26, alpha_upper),
 		"AAAA"
 	);
 	assert_eq!(
-		bijective_base(u64::max_value(), 3, alpha),
+		bijective_base(u64::max_value(), 3, alpha_upper),
 		"AAAABBABCBBABBAABCCAACCCACAACACCACCBAABBA"
 	);
 	assert_eq!(
-		bijective_base(u64::max_value(), 2, alpha),
+		bijective_base(u64::max_value(), 2, alpha_upper),
 		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB"
 	);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@
 //! [`serde`](https://github.com/serde-rs/serde).
 
 #![doc(html_root_url = "https://docs.rs/serde_closure/0.2.13")]
-#![feature(unboxed_closures, fn_traits)]
+#![cfg_attr(feature = "nightly", feature(unboxed_closures, fn_traits))]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,
@@ -203,6 +203,14 @@ pub use serde_closure_derive::FnMut;
 ///
 /// See the [readme](self) for examples.
 pub use serde_closure_derive::Fn;
+
+/// Attribute macro that can be applied to items to generalize trait bounds
+/// [`FnOnce(…)`](std::ops::FnOnce), [`FnMut(…)`](std::ops::FnMut) and
+/// [`Fn(…)`](std::ops::Fn) to [`traits::FnOnce<(…)>`](traits::FnOnce),
+/// [`traits::FnMut<(…)>`](traits::FnMut) and [`traits::Fn<(…)>`](traits::Fn).
+///
+/// See `tests/stable.rs` for examples.
+pub use serde_closure_derive::generalize;
 
 #[doc(hidden)]
 pub mod internal {
@@ -242,29 +250,132 @@ pub mod internal {
 	pub struct a_variable;
 }
 
+pub mod traits {
+	//! Supertraits of [`std::ops::FnOnce`], [`std::ops::FnMut`] and
+	//! [`std::ops::Fn`] that are usable on stable Rust. They are implemented
+	//! by closures created by the [`FnOnce`](macro@super::FnOnce),
+	//! [`FnMut`](macro@super::FnMut) and [`Fn`](macro@super::Fn) macros.
+	//!
+	//! See the [readme](super) for examples.
+
+	#![allow(non_snake_case)]
+
+	use std::ops;
+
+	/// Supertrait of [`std::ops::FnOnce`] that is usable on stable Rust. It is
+	/// implemented by closures created by the [`FnOnce`](macro@super::FnOnce)
+	/// macro.
+	///
+	/// See the [readme](super) for examples.
+	pub trait FnOnce<Args> {
+		/// The returned type after the call operator is used.
+		type Output;
+
+		/// Performs the call operation.
+		fn call_once(self, args: Args) -> Self::Output;
+	}
+
+	/// Supertrait of [`std::ops::FnMut`] that is usable on stable Rust. It is
+	/// implemented by closures created by the [`FnMut`](macro@super::FnMut)
+	/// macro.
+	///
+	/// See the [readme](super) for examples.
+	pub trait FnMut<Args>: FnOnce<Args> {
+		/// Performs the call operation.
+		fn call_mut(&mut self, args: Args) -> Self::Output;
+	}
+
+	/// Supertrait of [`std::ops::Fn`] that is usable on stable Rust. It is
+	/// implemented by closures created by the [`Fn`](macro@super::Fn)
+	/// macro.
+	///
+	/// See the [readme](super) for examples.
+	pub trait Fn<Args>: FnMut<Args> {
+		/// Performs the call operation.
+		fn call(&self, args: Args) -> Self::Output;
+	}
+
+	macro_rules! fn_once {
+		($($t:ident)*) => {
+			impl<T, $($t,)* O> FnOnce<($($t,)*)> for T
+			where
+				T: ops::FnOnce($($t,)*) -> O,
+			{
+				type Output = O;
+
+				fn call_once(self, ($($t,)*): ($($t,)*)) -> Self::Output {
+					self($($t,)*)
+				}
+			}
+			fn_once!(@recurse $($t)*);
+		};
+		(@recurse $first:ident $($t:ident)*) => {
+			fn_once!($($t)*);
+		};
+		(@recurse) => {};
+	}
+	fn_once!(A B C D E F G H I J K L);
+
+	macro_rules! fn_mut {
+		($($t:ident)*) => {
+			impl<T, $($t,)* O> FnMut<($($t,)*)> for T
+			where
+				T: ops::FnMut($($t,)*) -> O,
+			{
+				fn call_mut(&mut self, ($($t,)*): ($($t,)*)) -> Self::Output {
+					self($($t,)*)
+				}
+			}
+			fn_mut!(@recurse $($t)*);
+		};
+		(@recurse $first:ident $($t:ident)*) => {
+			fn_mut!($($t)*);
+		};
+		(@recurse) => {};
+	}
+	fn_mut!(A B C D E F G H I J K L);
+
+	macro_rules! fn_ref {
+		($($t:ident)*) => {
+			impl<T, $($t,)* O> Fn<($($t,)*)> for T
+			where
+				T: ops::Fn($($t,)*) -> O,
+			{
+				fn call(&self, ($($t,)*): ($($t,)*)) -> Self::Output {
+					self($($t,)*)
+				}
+			}
+			fn_ref!(@recurse $($t)*);
+		};
+		(@recurse $first:ident $($t:ident)*) => {
+			fn_ref!($($t)*);
+		};
+		(@recurse) => {};
+	}
+	fn_ref!(A B C D E F G H I J K L);
+}
+
 pub mod structs {
 	//! Structs representing a serializable closure, created by the
-	//! [`FnOnce`](macro@FnOnce), [`FnMut`](macro@FnMut) and [`Fn`](macro@Fn)
-	//! macros. They implement [`std::ops::FnOnce`], [`std::ops::FnMut`] and
-	//! [`std::ops::Fn`] respectively, as well as [`Debug`](std::fmt::Debug),
-	//! [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize),
-	//! and various convenience traits.
+	//! [`FnOnce`](macro@super::FnOnce), [`FnMut`](macro@super::FnMut) and
+	//! [`Fn`](macro@super::Fn) macros. They implement [`std::ops::FnOnce`],
+	//! [`std::ops::FnMut`] and [`std::ops::Fn`] respectively, as well as
+	//! [`Debug`](std::fmt::Debug), [`Serialize`](serde::Serialize) and
+	//! [`Deserialize`](serde::Deserialize), and various convenience traits.
 	//!
-	//! See the [readme](self) for examples.
+	//! See the [readme](super) for examples.
 
 	use serde::{Deserialize, Serialize};
-	use std::{
-		fmt::{self, Debug}, ops
-	};
+	use std::fmt::{self, Debug};
 
 	use super::internal;
 
 	/// A struct representing a serializable closure, created by the
-	/// [`FnOnce`](macro@FnOnce) macro. Implements [`std::ops::FnOnce`],
+	/// [`FnOnce`](macro@super::FnOnce) macro. Implements [`std::ops::FnOnce`],
 	/// [`Debug`], [`Serialize`] and [`Deserialize`], and various convenience
 	/// traits.
 	///
-	/// See the [readme](self) for examples.
+	/// See the [readme](super) for examples.
 	#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 	#[serde(transparent)]
 	pub struct FnOnce<F> {
@@ -281,7 +392,20 @@ pub mod structs {
 			Self { f }
 		}
 	}
-	impl<F, I> ops::FnOnce<I> for FnOnce<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::FnOnce<I> for FnOnce<F>
+	where
+		F: internal::FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::FnOnce<I> for FnOnce<F>
 	where
 		F: internal::FnOnce<I>,
 	{
@@ -291,6 +415,7 @@ pub mod structs {
 			self.f.call_once(args)
 		}
 	}
+
 	impl<F> Debug for FnOnce<F>
 	where
 		F: Debug,
@@ -301,11 +426,11 @@ pub mod structs {
 	}
 
 	/// A struct representing a serializable closure, created by the
-	/// [`FnMut`](macro@FnMut) macro. Implements [`std::ops::FnMut`],
+	/// [`FnMut`](macro@super::FnMut) macro. Implements [`std::ops::FnMut`],
 	/// [`Debug`], [`Serialize`] and [`Deserialize`], and various convenience
 	/// traits.
 	///
-	/// See the [readme](self) for examples.
+	/// See the [readme](super) for examples.
 	#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 	#[serde(transparent)]
 	pub struct FnMut<F> {
@@ -322,7 +447,20 @@ pub mod structs {
 			Self { f }
 		}
 	}
-	impl<F, I> ops::FnOnce<I> for FnMut<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::FnOnce<I> for FnMut<F>
+	where
+		F: internal::FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::FnOnce<I> for FnMut<F>
 	where
 		F: internal::FnOnce<I>,
 	{
@@ -332,7 +470,19 @@ pub mod structs {
 			self.f.call_once(args)
 		}
 	}
-	impl<F, I> ops::FnMut<I> for FnMut<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::FnMut<I> for FnMut<F>
+	where
+		F: internal::FnMut<I>,
+	{
+		#[inline(always)]
+		fn call_mut(&mut self, args: I) -> Self::Output {
+			self.f.call_mut(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::FnMut<I> for FnMut<F>
 	where
 		F: internal::FnMut<I>,
 	{
@@ -341,6 +491,7 @@ pub mod structs {
 			self.f.call_mut(args)
 		}
 	}
+
 	impl<F> Debug for FnMut<F>
 	where
 		F: Debug,
@@ -351,10 +502,10 @@ pub mod structs {
 	}
 
 	/// A struct representing a serializable closure, created by the
-	/// [`Fn`](macro@Fn) macro. Implements [`std::ops::Fn`], [`Debug`],
+	/// [`Fn`](macro@super::Fn) macro. Implements [`std::ops::Fn`], [`Debug`],
 	/// [`Serialize`] and [`Deserialize`], and various convenience traits.
 	///
-	/// See the [readme](self) for examples.
+	/// See the [readme](super) for examples.
 	#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 	#[serde(transparent)]
 	pub struct Fn<F> {
@@ -371,7 +522,20 @@ pub mod structs {
 			Self { f }
 		}
 	}
-	impl<F, I> ops::FnOnce<I> for Fn<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::FnOnce<I> for Fn<F>
+	where
+		F: internal::FnOnce<I>,
+	{
+		type Output = F::Output;
+		#[inline(always)]
+		fn call_once(self, args: I) -> Self::Output {
+			self.f.call_once(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::FnOnce<I> for Fn<F>
 	where
 		F: internal::FnOnce<I>,
 	{
@@ -381,7 +545,19 @@ pub mod structs {
 			self.f.call_once(args)
 		}
 	}
-	impl<F, I> ops::FnMut<I> for Fn<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::FnMut<I> for Fn<F>
+	where
+		F: internal::FnMut<I>,
+	{
+		#[inline(always)]
+		fn call_mut(&mut self, args: I) -> Self::Output {
+			self.f.call_mut(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::FnMut<I> for Fn<F>
 	where
 		F: internal::FnMut<I>,
 	{
@@ -390,7 +566,19 @@ pub mod structs {
 			self.f.call_mut(args)
 		}
 	}
-	impl<F, I> ops::Fn<I> for Fn<F>
+
+	#[cfg(not(feature = "nightly"))]
+	impl<F, I> super::traits::Fn<I> for Fn<F>
+	where
+		F: internal::Fn<I>,
+	{
+		#[inline(always)]
+		fn call(&self, args: I) -> Self::Output {
+			self.f.call(args)
+		}
+	}
+	#[cfg(feature = "nightly")]
+	impl<F, I> std::ops::Fn<I> for Fn<F>
 	where
 		F: internal::Fn<I>,
 	{
@@ -399,6 +587,7 @@ pub mod structs {
 			self.f.call(args)
 		}
 	}
+
 	impl<F> Debug for Fn<F>
 	where
 		F: Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! automatically serializable and deserializable with
 //! [`serde`](https://github.com/serde-rs/serde).
 
-#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.13")]
+#![doc(html_root_url = "https://docs.rs/serde_closure/0.2.14")]
 #![cfg_attr(feature = "nightly", feature(unboxed_closures, fn_traits))]
 #![warn(
 	missing_copy_implementations,

--- a/tests/stable.rs
+++ b/tests/stable.rs
@@ -1,0 +1,136 @@
+#![forbid(unsafe_code)]
+#![warn(
+	trivial_numeric_casts,
+	unused_import_braces,
+	unused_qualifications,
+	unused_results,
+	unreachable_pub,
+	clippy::pedantic
+)]
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::{fmt::Debug, hash::Hash};
+
+use serde_closure::{traits, Fn, FnMut, FnOnce};
+
+trait Various:
+	Clone + PartialEq + Eq + Hash + PartialOrd + Ord + Serialize + DeserializeOwned + Debug
+{
+}
+impl<T: ?Sized> Various for T where
+	T: Clone + PartialEq + Eq + Hash + PartialOrd + Ord + Serialize + DeserializeOwned + Debug
+{
+}
+
+#[serde_closure::generalize]
+trait Pool {
+	type Pool;
+
+	fn spawn<F, T>(&self, work: F) -> Result<T, ()>
+	where
+		F: FnOnce(&Self::Pool) -> T + 'static;
+
+	fn spawn2<F, T>(&self, work: F) -> Result<T, ()>
+	where
+		F: FnOnce() -> T + 'static;
+
+	fn spawn3<F: FnOnce(&Self::Pool) -> T + 'static, T>(&self, work: F) -> Result<T, ()>;
+}
+
+fn _generalize<P: Pool>(pool: &P) {
+	pool.spawn(FnOnce!(|_: &_| ())).unwrap();
+	pool.spawn2(FnOnce!(|| ())).unwrap();
+	pool.spawn3(FnOnce!(|_: &_| ())).unwrap();
+}
+
+#[test]
+fn fnonce() {
+	fn test<F, A, O>(_: F)
+	where
+		F: Various + traits::FnOnce<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(FnOnce!(|| ()));
+
+	let b = String::new();
+	test::<_, (String,), ()>(FnOnce!(move |_: String| drop(b)));
+}
+
+#[test]
+fn fnonce_plain() {
+	fn test<F, A, O>(_: F)
+	where
+		F: traits::FnOnce<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(|| ());
+
+	let b = String::new();
+	test::<_, (String,), ()>(move |_: String| drop(b));
+}
+
+#[test]
+fn fnmut() {
+	fn test<F, A, O>(_: F)
+	where
+		F: Various + traits::FnMut<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(FnMut!(|| ()));
+
+	let b = String::new();
+	test::<_, (String,), ()>(FnMut!(move |_: String| {
+		let _ = b.as_mut_str();
+	}));
+}
+
+#[test]
+fn fnmut_plain() {
+	fn test<F, A, O>(_: F)
+	where
+		F: traits::FnMut<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(|| ());
+
+	let mut b = String::new();
+	test::<_, (String,), ()>(move |_: String| {
+		let _ = b.as_mut_str();
+	});
+}
+
+#[test]
+fn fnref() {
+	fn test<F, A, O>(_: F)
+	where
+		F: Various + traits::Fn<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(Fn!(|| ()));
+
+	let b = String::new();
+	test::<_, (String,), ()>(Fn!(move |_: String| {
+		let _ = b.as_str();
+	}));
+}
+
+#[test]
+fn fnref_plain() {
+	fn test<F, A, O>(_: F)
+	where
+		F: traits::Fn<A, Output = O>,
+	{
+	}
+
+	test::<_, (), ()>(|| ());
+
+	let b = String::new();
+	test::<_, (String,), ()>(move |_: String| {
+		let _ = b.as_str();
+	});
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_code)] // TODO: make this forbid when unsafe in a macro doesn't trigger it (def_site?)
+#![forbid(unsafe_code)]
 #![warn(
 	trivial_numeric_casts,
 	unused_import_braces,
@@ -13,11 +13,6 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, mem::size_of};
 
 use serde_closure::{Fn, FnMut, FnOnce};
-
-#[test]
-fn fn_ptr_size() {
-	assert_eq!(size_of::<usize>(), size_of::<fn()>());
-}
 
 #[test]
 fn fnonce() {


### PR DESCRIPTION
Add a default feature `nightly` that, when disabled, enables usage on stable Rust.

Similar `Fn*` traits are exposed that are implemented for all `Fn*(...)` (up to 12 args) as well as the structs returned by the macros in this crate.

On stable, generated closures impl: `serde_closure::traits::Fn*`

On nightly, generated closures impl: `serde_closure::traits::Fn*` and `core::ops::Fn*`